### PR TITLE
Channel and Datarate Selection

### DIFF
--- a/TinyLoRa.cpp
+++ b/TinyLoRa.cpp
@@ -170,51 +170,51 @@ void TinyLoRa::setChannel(rfm_channels_t channel) {
   switch (channel)
   {
     case CH0:
-      _rfmLSB = pgm_read_byte(&(LoRa_Frequency[0][0]));
+      _rfmLSB = pgm_read_byte(&(LoRa_Frequency[0][2]));
       _rfmMID = pgm_read_byte(&(LoRa_Frequency[0][1]));
-      _rfmMSB = pgm_read_byte(&(LoRa_Frequency[0][2]));
+      _rfmMSB = pgm_read_byte(&(LoRa_Frequency[0][0]));
       _isMultiChan = 0;
       break;
     case CH1:
-      _rfmLSB = pgm_read_byte(&(LoRa_Frequency[1][0]));
+      _rfmLSB = pgm_read_byte(&(LoRa_Frequency[1][2]));
       _rfmMID = pgm_read_byte(&(LoRa_Frequency[1][1]));
-      _rfmMSB = pgm_read_byte(&(LoRa_Frequency[1][2]));
+      _rfmMSB = pgm_read_byte(&(LoRa_Frequency[1][0]));
       _isMultiChan = 0;
       break;
     case CH2:
-      _rfmLSB = pgm_read_byte(&(LoRa_Frequency[2][0]));
+      _rfmLSB = pgm_read_byte(&(LoRa_Frequency[2][2]));
       _rfmMID = pgm_read_byte(&(LoRa_Frequency[2][1]));
-      _rfmMSB = pgm_read_byte(&(LoRa_Frequency[2][2]));
+      _rfmMSB = pgm_read_byte(&(LoRa_Frequency[2][0]));
       _isMultiChan = 0;
       break;
     case CH3:
-      _rfmLSB = pgm_read_byte(&(LoRa_Frequency[3][0]));
+      _rfmLSB = pgm_read_byte(&(LoRa_Frequency[3][2]));
       _rfmMID = pgm_read_byte(&(LoRa_Frequency[3][1]));
-      _rfmMSB = pgm_read_byte(&(LoRa_Frequency[3][2]));
+      _rfmMSB = pgm_read_byte(&(LoRa_Frequency[3][0]));
       _isMultiChan = 0;
       break;
     case CH4:
-      _rfmLSB = pgm_read_byte(&(LoRa_Frequency[4][0]));
+      _rfmLSB = pgm_read_byte(&(LoRa_Frequency[4][2]));
       _rfmMID = pgm_read_byte(&(LoRa_Frequency[4][1]));
-      _rfmMSB = pgm_read_byte(&(LoRa_Frequency[4][2]));
+      _rfmMSB = pgm_read_byte(&(LoRa_Frequency[4][0]));
       _isMultiChan = 0;
       break;
     case CH5:
-      _rfmLSB = pgm_read_byte(&(LoRa_Frequency[5][0]));
+      _rfmLSB = pgm_read_byte(&(LoRa_Frequency[5][2]));
       _rfmMID = pgm_read_byte(&(LoRa_Frequency[5][1]));
-      _rfmMSB = pgm_read_byte(&(LoRa_Frequency[5][2]));
+      _rfmMSB = pgm_read_byte(&(LoRa_Frequency[5][0]));
       _isMultiChan = 0;
       break;
     case CH6:
-      _rfmLSB = pgm_read_byte(&(LoRa_Frequency[6][0]));
+      _rfmLSB = pgm_read_byte(&(LoRa_Frequency[6][2]));
       _rfmMID = pgm_read_byte(&(LoRa_Frequency[6][1]));
-      _rfmMSB = pgm_read_byte(&(LoRa_Frequency[6][2]));
+      _rfmMSB = pgm_read_byte(&(LoRa_Frequency[6][0]));
       _isMultiChan = 0;
       break;
     case CH7:
-      _rfmLSB = pgm_read_byte(&(LoRa_Frequency[7][0]));
+      _rfmLSB = pgm_read_byte(&(LoRa_Frequency[7][2]));
       _rfmMID = pgm_read_byte(&(LoRa_Frequency[7][1]));
-      _rfmMSB = pgm_read_byte(&(LoRa_Frequency[7][2]));
+      _rfmMSB = pgm_read_byte(&(LoRa_Frequency[7][0]));
       _isMultiChan = 0;
       break;
     case MULTI:
@@ -465,7 +465,9 @@ void TinyLoRa::sendData(unsigned char *Data, unsigned char Data_Length, unsigned
  
   //Send Package
   RFM_Send_Package(RFM_Data, RFM_Package_Length);
-  Serial.println("sent package!");
+  #ifdef DEBUG
+    Serial.println("sent package!");
+  #endif
 }
 /*
 *****************************************************************************************

--- a/TinyLoRa.cpp
+++ b/TinyLoRa.cpp
@@ -1,25 +1,43 @@
-/******************************************************************************************
-* Copyright 2015, 2016 Ideetron B.V.
-*
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU Lesser General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU Lesser General Public License for more details.
-*
-* You should have received a copy of the GNU Lesser General Public License
-* along with this program.  If not, see <http://www.gnu.org/licenses/>.
-******************************************************************************************/
+/*!
+ * @file TinyLoRa.cpp
+ *
+ * @mainpage TinyLoRa RFM95/96W breakout driver
+ *
+ * @section intro_sec Introduction
+ *
+ * This is the documentation for Adafruit's Feather LoRa for the
+ * Arduino platform. It is designed specifically to work with the
+ * Adafruit Feather 32u4 LoRa: 
+ * This is the documentation for Adafruit's FXOS8700 driver for the
+ * Arduino platform.  It is designed specifically to work with the
+ * Adafruit FXOS8700 breakout: https://www.adafruit.com/product/3078
+ *
+ * This library uses SPI to communicate, 4 pins (SCL, SDA, IRQ, SS)
+ * are required to interface with the HopeRF RFM95/96 breakout.
+ *
+ * Adafruit invests time and resources providing this open source code,
+ * please support Adafruit and open-source hardware by purchasing
+ * products from Adafruit!
+ *
+ * @section dependencies Dependencies
+ *
+ * This library has no dependencies.
+ *
+ * @section author Author
+ *
+ * Written by Ideetron B.V., modified by Brent Rubell for Adafruit Industries.
+ *
+ * @section license License
+ *
+ * BSD license, all text here must be included in any redistribution.
+ *
+ */
 #include "TinyLoRa.h"
 #include <SPI.h>
 
-extern uint8_t NwkSkey[16];
-extern uint8_t AppSkey[16];
-extern uint8_t DevAddr[4];
+extern uint8_t NwkSkey[16]; ///< Network Session Key
+extern uint8_t AppSkey[16]; ///< Application Session Key
+extern uint8_t DevAddr[4]; ///< Device Address
 
 static SPISettings RFM_spisettings = SPISettings(4000000, MSBFIRST, SPI_MODE0);
 
@@ -108,10 +126,14 @@ static const unsigned char PROGMEM TinyLoRa::S_Table[16][16] = {
 	  {0x8C,0xA1,0x89,0x0D,0xBF,0xE6,0x42,0x68,0x41,0x99,0x2D,0x0F,0xB0,0x54,0xBB,0x16}
 	};
 
+/***************************************************************************
+ CONSTRUCTORS
+ ***************************************************************************/
+
 /**************************************************************************/
 /*! 
-    @brief Set the RFM datarate
-    @param channel Which channel to send data
+    @brief Sets the RFM datarate
+    @param datarate Bandwidth and Frequency plan.
 */
 /**************************************************************************/
 void TinyLoRa::setDatarate(rfm_datarates_t datarate) {
@@ -159,9 +181,10 @@ void TinyLoRa::setDatarate(rfm_datarates_t datarate) {
       break;
   }
 }
+
 /**************************************************************************/
 /*! 
-    @brief Set the RFM channel.
+    @brief Sets the RFM channel.
     @param channel Which channel to send data
 */
 /**************************************************************************/
@@ -227,22 +250,30 @@ void TinyLoRa::setChannel(rfm_channels_t channel) {
 }
 
 /**************************************************************************/
-/*! 
-    @brief constructor initializes provided pin values
-    @param rfm_irq interrupt pin (rfm_nss)
-    @parm rfm_nss ss pin (rfm_nss)
+/*!
+    @brief  Instanciates a new TinyLoRa class, including assigning
+            irq and cs pins to the RFM breakout.
+    @param    rfm_irq
+              The RFM module's interrupt pin (rfm_nss).
+    @param    rfm_nss
+              The RFM module's slave select pin (rfm_nss).
 */
 /**************************************************************************/
-TinyLoRa::TinyLoRa(int8_t rfm__irq, int8_t rfm_nss) {
-  _irq = rfm__irq;
+TinyLoRa::TinyLoRa(int8_t rfm_irq, int8_t rfm_nss) {
+  _irq = rfm_irq;
   _cs = rfm_nss;
 }
 
-/*
-*****************************************************************************************
-* Description: Function used to initialize the RFM module on startup
-*****************************************************************************************
-*/
+/***************************************************************************
+ PUBLIC FUNCTIONS
+ ***************************************************************************/
+
+ /**************************************************************************/
+ /*!
+     @brief  Initializes the RFM, including configuring SPI, configuring
+             the frameCounter and txrandomNum. 
+ */
+ /**************************************************************************/
 void TinyLoRa::begin() 
 {
 
@@ -299,14 +330,15 @@ void TinyLoRa::begin()
 
 }
 
-/*
-*****************************************************************************************
-* Description : Function for sending a package with the RFM
-*
-* Arguments   : *RFM_Tx_Package Pointer to arry with data to be send
-*               Package_Length  Length of the package to send
-*****************************************************************************************
+/**************************************************************************/
+/*!
+    @brief  Sends a package with the RFM module.
+    @param    *RFM_Tx_Package
+              Pointer to array containing data to be sent.
+    @param    Package_Length
+              Length of the package to be sent.
 */
+/**************************************************************************/
 void TinyLoRa::RFM_Send_Package(unsigned char *RFM_Tx_Package, unsigned char Package_Length)
 {
   unsigned char i;
@@ -360,14 +392,15 @@ void TinyLoRa::RFM_Send_Package(unsigned char *RFM_Tx_Package, unsigned char Pac
   RFM_Write(0x01,MODE_SLEEP);
 }
 
-/*
-*****************************************************************************************
-* Description : Funtion that writes a register from the RFM
-*
-* Arguments   : RFM_Address Address of register to be written
-*         RFM_Data    Data to be written
-*****************************************************************************************
+/**************************************************************************/
+/*!
+    @brief    Function which writes to a register from the RFM.
+    @param    RFM_Address
+              An address of the register to be written.
+    @param    RFM_Data
+              Data to be written to the register.
 */
+/**************************************************************************/
 void TinyLoRa::RFM_Write(unsigned char RFM_Address, unsigned char RFM_Data) 
 {
   // br: SPI Transfer Debug
@@ -391,15 +424,18 @@ void TinyLoRa::RFM_Write(unsigned char RFM_Address, unsigned char RFM_Data)
   //Set NSS pin High to end communication
   digitalWrite(_cs, HIGH);
 }
-/*
-*****************************************************************************************
-* Description : Function contstructs a LoRaWAN package and sends it
-*
-* Arguments   : *Data pointer to the array of data that will be transmitted
-*               Data_Length nuber of bytes to be transmitted
-*               Frame_Counter_Up  Frame counter of upstream frames
-*****************************************************************************************
+
+/**************************************************************************/
+/*!
+    @brief    Function to assemble and send a LoRaWAN package.
+    @param    *Data
+              Pointer to the array of data to be transmitted.
+    @param    Frame_Counter_Tx
+              Frame counter for transfer frames.
+    @param    Data_Length
+              Length of data to be sent.
 */
+/**************************************************************************/
 void TinyLoRa::sendData(unsigned char *Data, unsigned char Data_Length, unsigned int Frame_Counter_Tx)
 {
   
@@ -469,16 +505,21 @@ void TinyLoRa::sendData(unsigned char *Data, unsigned char Data_Length, unsigned
     Serial.println("sent package!");
   #endif
 }
-/*
-*****************************************************************************************
-* Description : Function used to encrypt and decrypt the data in a LoRaWAN data message
-*
-* Arguments   : *Data pointer to the data to de/encrypt
-*				Data_Length nuber of bytes to be transmitted
-*               Frame_Counter_Up  Frame counter of upstream frames
-*				Direction of msg is up
-*****************************************************************************************
+
+/**************************************************************************/
+/*!
+    @brief    Function used to encrypt and decrypt the data in a LoRaWAN
+              data packet.
+    @param    *Data
+              Pointer to the data to decrypt or encrypt.
+    @param    Data_Length
+              Number of bytes to be transmitted.
+    @param    Frame_Counter
+              Counts upstream frames.
+    @param    Direction
+              Direction of message (is up).
 */
+/**************************************************************************/
 void TinyLoRa::Encrypt_Payload(unsigned char *Data, unsigned char Data_Length, unsigned int Frame_Counter, unsigned char Direction)
 {
   unsigned char i = 0x00;
@@ -548,17 +589,22 @@ void TinyLoRa::Encrypt_Payload(unsigned char *Data, unsigned char Data_Length, u
     }
   }
 }
-/*
-*****************************************************************************************
-* Description : Function used to calculate the MIC of data
-*
-* Arguments   : *Data pointer to the data to de/encrypt
-*				Data_Length nuber of bytes to be transmitted
-*				MIC Array of 4 bytes
-*				Frame_Counter_Up  Frame counter of upstream frames
-*				Direction of msg is up
-*****************************************************************************************
+
+/**************************************************************************/
+/*!
+    @brief    Function used to calculate the validity of data messages.
+    @param    *Data
+              Pointer to the data to decrypt or encrypt.
+    @param    Data_Length
+              Number of bytes to be transmitted.
+    @param    *Final_Mic
+              Pointer to MIC array (4 bytes).
+    @param    Frame_Counter
+              Frame counter of upstream frames.
+    @param    Direction
+              Direction of message (is up?).
 */
+/**************************************************************************/
 void TinyLoRa::Calculate_MIC(unsigned char *Data, unsigned char *Final_MIC, unsigned char Data_Length, unsigned int Frame_Counter, unsigned char Direction)
 {
   unsigned char i;
@@ -723,14 +769,16 @@ void TinyLoRa::Calculate_MIC(unsigned char *Data, unsigned char *Final_MIC, unsi
   txrandomNum = Final_MIC[2] & 0x07;
 
 }
-/*
-*****************************************************************************************
-* Description : Function used to generate keys for the MIC calculation
-*
-* Arguments   : *K1 pointer to Key1
-*				*K2 pointer ot Key2
-*****************************************************************************************
+
+/**************************************************************************/
+/*!
+    @brief    Function used to generate keys for the MIC calculation.
+    @param    *K1
+              Pointer to Key1.
+    @param    *K2
+              Pointer to Key2.
 */
+/**************************************************************************/
 void TinyLoRa::Generate_Keys(unsigned char *K1, unsigned char *K2)
 {
   unsigned char i;
@@ -815,6 +863,15 @@ void TinyLoRa::Shift_Left(unsigned char *Data)
   }
 }
 
+/**************************************************************************/
+/*!
+    @brief    Function to XOR two character arrays.
+    @param    *New_Data
+              A pointer to the calculated data.
+    @param    *Old_Data
+              A pointer to the data to be xor'd.
+*/
+/**************************************************************************/
 void TinyLoRa::XOR(unsigned char *New_Data,unsigned char *Old_Data)
 {
   unsigned char i;
@@ -824,12 +881,16 @@ void TinyLoRa::XOR(unsigned char *New_Data,unsigned char *Old_Data)
     New_Data[i] = New_Data[i] ^ Old_Data[i];
   }
 }
-/*
-*****************************************************************************************
-* Title         : AES_Encrypt
-* Description  : 
-*****************************************************************************************
+
+/**************************************************************************/
+/*!
+    @brief    Function used to perform AES encryption.
+    @param    *Data
+              Pointer to the data to decrypt or encrypt.
+    @param    *Key
+              Pointer to AES encryption key.
 */
+/**************************************************************************/
 void TinyLoRa::AES_Encrypt(unsigned char *Data, unsigned char *Key)
 {
   unsigned char Row, Column, Round = 0;
@@ -902,15 +963,17 @@ void TinyLoRa::AES_Encrypt(unsigned char *Data, unsigned char *Key)
       Data[Row + (Column << 2)] = State[Row][Column];
     }
   }
-} // AES_Encrypt
+}
 
-
-/*
-*****************************************************************************************
-* Title         : AES_Add_Round_Key
-* Description : 
-*****************************************************************************************
+/**************************************************************************/
+/*!
+    @brief    Function performs AES AddRoundKey step.
+    @param    *Round_Key
+              Pointer to the round subkey.
+    @param    *State
+              Pointer to bytes of the states-to-be-xor'd.
 */
+/**************************************************************************/
 void TinyLoRa::AES_Add_Round_Key(unsigned char *Round_Key, unsigned char (*State)[4])
 {
   unsigned char Row, Collum;
@@ -922,15 +985,15 @@ void TinyLoRa::AES_Add_Round_Key(unsigned char *Round_Key, unsigned char (*State
       State[Row][Collum] ^= Round_Key[Row + (Collum << 2)];
     }
   }
-} // AES_Add_Round_Key
+}
 
-
-/*
-*****************************************************************************************
-* Title         : AES_Sub_Byte
-* Description : 
-*****************************************************************************************
+/**************************************************************************/
+/*!
+    @brief    Function performs AES SubBytes step.
+    @param    Byte
+              Individual byte, from state array.
 */
+/**************************************************************************/
 unsigned char TinyLoRa::AES_Sub_Byte(unsigned char Byte)
 {
 //  unsigned char S_Row,S_Collum;
@@ -942,15 +1005,15 @@ unsigned char TinyLoRa::AES_Sub_Byte(unsigned char Byte)
 
   //return S_Table [ ((Byte >> 4) & 0x0F) ] [ ((Byte >> 0) & 0x0F) ]; // original
   return pgm_read_byte(&(S_Table [((Byte >> 4) & 0x0F)] [((Byte >> 0) & 0x0F)]));
-} //    AES_Sub_Byte
+}
 
-
-/*
-*****************************************************************************************
-* Title         : AES_Shift_Rows
-* Description : 
-*****************************************************************************************
+/**************************************************************************/
+/*!
+    @brief    Function performs AES ShiftRows step.
+    @param    *State
+              Pointer to state array.
 */
+/**************************************************************************/
 void TinyLoRa::AES_Shift_Rows(unsigned char (*State)[4])
 {
   unsigned char Buffer;
@@ -977,12 +1040,13 @@ void TinyLoRa::AES_Shift_Rows(unsigned char (*State)[4])
   State[3][0] = Buffer;
 }
 
-/*
-*****************************************************************************************
-* Title         : AES_Mix_Collums
-* Description : 
-*****************************************************************************************
+/**************************************************************************/
+/*!
+    @brief    Function performs AES MixColumns step.
+    @param    *State
+              Pointer to state array.
 */
+/**************************************************************************/
 void TinyLoRa::AES_Mix_Collums(unsigned char (*State)[4])
 {
   unsigned char Row,Collum;
@@ -1011,12 +1075,15 @@ void TinyLoRa::AES_Mix_Collums(unsigned char (*State)[4])
 
 
 
-/*
-*****************************************************************************************
-* Title         : AES_Calculate_Round_Key
-* Description : 
-*****************************************************************************************
+/**************************************************************************/
+/*!
+    @brief    Function performs AES Round Key Calculation.
+    @param    Round
+              Number of rounds to perform (depends on key size).
+    @param    Round_Key
+              Pointer to round key.
 */
+/**************************************************************************/
 void TinyLoRa::AES_Calculate_Round_Key(unsigned char Round, unsigned char *Round_Key)
 {
   unsigned char i, j, b, Rcon;

--- a/TinyLoRa.cpp
+++ b/TinyLoRa.cpp
@@ -272,55 +272,55 @@ void TinyLoRa::RFM_Send_Package(unsigned char *RFM_Tx_Package, unsigned char Pac
 
   // Select which channel to send data on 
   if (_isMultiChan == 1) {
-    RFM_Write(RegFrfMsb, pgm_read_byte(&(LoRa_Frequency[randomNum][0])));
-    RFM_Write(RegFrfMid, pgm_read_byte(&(LoRa_Frequency[randomNum][1])));
-    RFM_Write(RegFrfLsb, pgm_read_byte(&(LoRa_Frequency[randomNum][2])));
+    RFM_Write(REG_FRF_MSB, pgm_read_byte(&(LoRa_Frequency[randomNum][0])));
+    RFM_Write(REG_FRF_MID, pgm_read_byte(&(LoRa_Frequency[randomNum][1])));
+    RFM_Write(REG_FRF_LSB, pgm_read_byte(&(LoRa_Frequency[randomNum][2])));
   } else {
-    RFM_Write(RegFrfMsb, _rfmMSB);
-    RFM_Write(RegFrfMid, _rfmMID);
-    RFM_Write(RegFrfLsb, _rfmLSB);
+    RFM_Write(REG_FRF_MSB, _rfmMSB);
+    RFM_Write(REG_FRF_MID, _rfmMID);
+    RFM_Write(REG_FRF_LSB, _rfmLSB);
   }
 
 #ifdef SF12BW125         //SF12 BW 125 kHz
-  RFM_Write(0x1E, 0xC4); //SF12 CRC On
-  RFM_Write(0x1D, 0x72); //125 kHz 4/5 coding rate explicit header mode
-  RFM_Write(0x26, 0x0C); //Low datarate optimization on AGC auto on
+  RFM_Write(REG_FEI_LSB, 0xC4); //SF12 CRC On
+  RFM_Write(REG_FEI_MSB, 0x72); //125 kHz 4/5 coding rate explicit header mode
+  RFM_Write(REG_MODEM_CONFIG, 0x0C); //Low datarate optimization on AGC auto on
 #endif
 
 #ifdef SF11BW125         //SF11 BW 125 kHz
-  RFM_Write(0x1E, 0xB4); //SF11 CRC On
-  RFM_Write(0x1D, 0x72); //125 kHz 4/5 coding rate explicit header mode
-  RFM_Write(0x26, 0x0C); //Low datarate optimization on AGC auto on
+  RFM_Write(REG_FEI_LSB, 0xB4); //SF11 CRC On
+  RFM_Write(REG_FEI_MSB, 0x72); //125 kHz 4/5 coding rate explicit header mode
+  RFM_Write(REG_MODEM_CONFIG, 0x0C); //Low datarate optimization on AGC auto on
 #endif
 
 #ifdef SF10BW125         //SF10 BW 125 kHz
-  RFM_Write(0x1E, 0xA4); //SF10 CRC On
-  RFM_Write(0x1D, 0x72); //125 kHz 4/5 coding rate explicit header mode
-  RFM_Write(0x26, 0x04); //Low datarate optimization off AGC auto on
+  RFM_Write(REG_FEI_LSB, 0xA4); //SF10 CRC On
+  RFM_Write(REG_FEI_MSB, 0x72); //125 kHz 4/5 coding rate explicit header mode
+  RFM_Write(REG_MODEM_CONFIG, 0x04); //Low datarate optimization off AGC auto on
 #endif
 
 #ifdef SF9BW125          //SF9 BW 125 kHz
-  RFM_Write(0x1E, 0x94); //SF9 CRC On
-  RFM_Write(0x1D, 0x72); //125 kHz 4/5 coding rate explicit header mode
-  RFM_Write(0x26, 0x04); //Low datarate optimization off AGC auto on
+  RFM_Write(REG_FEI_LSB, 0x94); //SF9 CRC On
+  RFM_Write(REG_FEI_MSB, 0x72); //125 kHz 4/5 coding rate explicit header mode
+  RFM_Write(REG_MODEM_CONFIG, 0x04); //Low datarate optimization off AGC auto on
 #endif
 
 #ifdef SF8BW125          //SF8 BW 125 kHz
-  RFM_Write(0x1E, 0x84); //SF8 CRC On
-  RFM_Write(0x1D, 0x72); //125 kHz 4/5 coding rate explicit header mode
-  RFM_Write(0x26, 0x04); //Low datarate optimization off AGC auto on
+  RFM_Write(REG_FEI_LSB, 0x84); //SF8 CRC On
+  RFM_Write(REG_FEI_MSB, 0x72); //125 kHz 4/5 coding rate explicit header mode
+  RFM_Write(REG_MODEM_CONFIG, 0x04); //Low datarate optimization off AGC auto on
 #endif
 
 #ifdef SF7BW125          //SF7 BW 125 kHz
-  RFM_Write(0x1E, 0x74); //SF7 CRC On
-  RFM_Write(0x1D, 0x72); //125 kHz 4/5 coding rate explicit header mode
-  RFM_Write(0x26, 0x04); //Low datarate optimization off AGC auto on
+  RFM_Write(REG_FEI_LSB, 0x74); //SF7 CRC On
+  RFM_Write(REG_FEI_MSB, 0x72); //125 kHz 4/5 coding rate explicit header mode
+  RFM_Write(REG_MODEM_CONFIG, 0x04); //Low datarate optimization off AGC auto on
 #endif
 
 #ifdef SF7BW250          //SF7 BW 250kHz
-  RFM_Write(0x1E, 0x74); //SF7 CRC On
-  RFM_Write(0x1D, 0x82); //250 kHz 4/5 coding rate explicit header mode
-  RFM_Write(0x26, 0x04); //Low datarate optimization off AGC auto on
+  RFM_Write(REG_FEI_LSB, 0x74); //SF7 CRC On
+  RFM_Write(REG_FEI_MSB, 0x82); //250 kHz 4/5 coding rate explicit header mode
+  RFM_Write(REG_MODEM_CONFIG, 0x04); //Low datarate optimization off AGC auto on
 #endif 
 
   //Set payload length to the right length

--- a/TinyLoRa.cpp
+++ b/TinyLoRa.cpp
@@ -153,6 +153,9 @@ void TinyLoRa::setDatarate(rfm_datarates_t datarate) {
       _modemcfg = 0x0C;
       break;
     default:
+      _sf = 0x74;
+      _bw = 0x72;
+      _modemcfg = 0x04;
       break;
   }
 }
@@ -218,6 +221,7 @@ void TinyLoRa::setChannel(rfm_channels_t channel) {
       _isMultiChan = 1;
       break;
     default:
+      _isMultiChan = 1;
       break;
   }
 }

--- a/TinyLoRa.cpp
+++ b/TinyLoRa.cpp
@@ -116,8 +116,8 @@ static const unsigned char PROGMEM TinyLoRa::S_Table[16][16] = {
 
 /**************************************************************************/
 /*! 
-    @brief Set the single-channel to send
-    @param channel Which channel to send data on
+    @brief Set the RFM channel.
+    @param channel Which channel to send data
 */
 /**************************************************************************/
 void TinyLoRa::setChannel(rfm_channels_t channel)
@@ -129,35 +129,55 @@ void TinyLoRa::setChannel(rfm_channels_t channel)
       _rfmLSB = 0xE1;
       _rfmMID = 0xF9;
       _rfmMSB = 0xC0;
+      _isMultiChan = 0;
       break;
     case CH1:
       _rfmLSB = 0xE2;
       _rfmMID = 0x06;
       _rfmMSB = 0x8C;
+      _isMultiChan = 0;
       break;
     case CH2:
       _rfmLSB = 0xE2;
       _rfmMID = 0x13;
       _rfmMSB = 0x59;
+      _isMultiChan = 0;
       break;
     case CH3:
       _rfmLSB = 0xE2;
       _rfmMID = 0x20;
       _rfmMSB = 0x26;
+      _isMultiChan = 0;
       break;
     case CH4:
       _rfmLSB = 0xE2;
       _rfmMID = 0x2C;
       _rfmMSB = 0xF3;
+      _isMultiChan = 0;
       break;
     case CH5:
       _rfmLSB = 0xE2;
       _rfmMID = 0x39;
       _rfmMSB = 0xC0;
+      _isMultiChan = 0;
+      break;
     case CH6:
       _rfmLSB = 0xE2;
       _rfmMID = 0x46;
       _rfmMSB = 0x8C;
+      _isMultiChan = 0;
+      break;
+    case CH7:
+      _rfmLSB = 0xE2;
+      _rfmMID = 0x53;
+      _rfmMSB = 0x59;
+      _isMultiChan = 0;
+      break;
+    case MULTI:
+      _isMultiChan = 1;
+      break;
+    default:
+      break;
   }
 }
 
@@ -250,19 +270,29 @@ void TinyLoRa::RFM_Send_Package(unsigned char *RFM_Tx_Package, unsigned char Pac
   //Switch _irq to TxDone
   RFM_Write(0x40,0x40);
 
-// Single Channel Send on CH6, 903.9MHz
-// 0xE1, 0xF9, 0xC0
-#ifdef SGLCH
-  RFM_Write(RegFrfMsb, _rfmMSB);
-  RFM_Write(RegFrfMid, _rfmMID);
-  RFM_Write(RegFrfLsb, _rfmLSB);
-#endif
+  if (_isMultiChan == 1) {
+    Serial.println("Multi Channel enabled");
+    RFM_Write(RegFrfMsb, pgm_read_byte(&(LoRa_Frequency[randomNum][0])));
+    RFM_Write(RegFrfMid, pgm_read_byte(&(LoRa_Frequency[randomNum][1])));
+    RFM_Write(RegFrfLsb, pgm_read_byte(&(LoRa_Frequency[randomNum][2])));
+  } else {
+    Serial.println("Single Channel enabled");
+    RFM_Write(RegFrfMsb, _rfmMSB);
+    RFM_Write(RegFrfMid, _rfmMID);
+    RFM_Write(RegFrfLsb, _rfmLSB);
+  }
 
-#ifdef MULTICH
-  RFM_Write(RegFrfMsb, pgm_read_byte(&(LoRa_Frequency[randomNum][0])));
-  RFM_Write(RegFrfMid, pgm_read_byte(&(LoRa_Frequency[randomNum][1])));
-  RFM_Write(RegFrfLsb, pgm_read_byte(&(LoRa_Frequency[randomNum][2])));
-#endif
+// #ifdef SGLCH
+//   RFM_Write(RegFrfMsb, _rfmMSB);
+//   RFM_Write(RegFrfMid, _rfmMID);
+//   RFM_Write(RegFrfLsb, _rfmLSB);
+// #endif
+
+// #ifdef MULTICH
+//   RFM_Write(RegFrfMsb, pgm_read_byte(&(LoRa_Frequency[randomNum][0])));
+//   RFM_Write(RegFrfMid, pgm_read_byte(&(LoRa_Frequency[randomNum][1])));
+//   RFM_Write(RegFrfLsb, pgm_read_byte(&(LoRa_Frequency[randomNum][2])));
+// #endif
 
 #ifdef SF12BW125         //SF12 BW 125 kHz
   RFM_Write(0x1E, 0xC4); //SF12 CRC On

--- a/TinyLoRa.cpp
+++ b/TinyLoRa.cpp
@@ -110,17 +110,63 @@ static const unsigned char PROGMEM TinyLoRa::S_Table[16][16] = {
 
 /**************************************************************************/
 /*! 
+    @brief Set the RFM datarate
+    @param channel Which channel to send data
+*/
+/**************************************************************************/
+void TinyLoRa::setDatarate(rfm_datarates_t datarate) {
+  _sf, _bw, _modemcfg = 0;
+  switch(datarate) {
+    case SF7BW125:
+      _sf = 0x74;
+      _bw = 0x72;
+      _modemcfg = 0x04;
+      break;
+    case SF7BW250:
+      _sf = 0x74;
+      _bw = 0x82;
+      _modemcfg = 0x04;
+      break;
+    case SF8BW125:
+      _sf = 0x84;
+      _bw = 0x72;
+      _modemcfg = 0x04;
+      break;
+    case SF9BW125:
+      _sf = 0x94;
+      _bw = 0x72;
+      _modemcfg = 0x04;
+      break;
+    case SF10BW125:
+      _sf = 0xA4;
+      _bw = 0x72;
+      _modemcfg = 0x04;
+      break;
+    case SF11BW125:
+      _sf = 0xB4;
+      _bw = 0x72;
+      _modemcfg = 0x0C;
+      break;
+    case SF12BW125:
+      _sf = 0xC4;
+      _bw = 0x72;
+      _modemcfg = 0x0C;
+      break;
+    default:
+      break;
+  }
+}
+/**************************************************************************/
+/*! 
     @brief Set the RFM channel.
     @param channel Which channel to send data
 */
 /**************************************************************************/
-void TinyLoRa::setChannel(rfm_channels_t channel)
-{
+void TinyLoRa::setChannel(rfm_channels_t channel) {
   _rfmMSB, _rfmLSB, _rfmMID = 0;
   switch (channel)
   {
     case CH0:
-      Serial.println("Freq Test: ");
       _rfmLSB = pgm_read_byte(&(LoRa_Frequency[0][0]));
       _rfmMID = pgm_read_byte(&(LoRa_Frequency[0][1]));
       _rfmMSB = pgm_read_byte(&(LoRa_Frequency[0][2]));
@@ -270,7 +316,7 @@ void TinyLoRa::RFM_Send_Package(unsigned char *RFM_Tx_Package, unsigned char Pac
   //Switch _irq to TxDone
   RFM_Write(0x40,0x40);
 
-  // Select which channel to send data on 
+  // select rfm channel
   if (_isMultiChan == 1) {
     RFM_Write(REG_FRF_MSB, pgm_read_byte(&(LoRa_Frequency[randomNum][0])));
     RFM_Write(REG_FRF_MID, pgm_read_byte(&(LoRa_Frequency[randomNum][1])));
@@ -281,47 +327,10 @@ void TinyLoRa::RFM_Send_Package(unsigned char *RFM_Tx_Package, unsigned char Pac
     RFM_Write(REG_FRF_LSB, _rfmLSB);
   }
 
-#ifdef SF12BW125         //SF12 BW 125 kHz
-  RFM_Write(REG_FEI_LSB, 0xC4); //SF12 CRC On
-  RFM_Write(REG_FEI_MSB, 0x72); //125 kHz 4/5 coding rate explicit header mode
-  RFM_Write(REG_MODEM_CONFIG, 0x0C); //Low datarate optimization on AGC auto on
-#endif
-
-#ifdef SF11BW125         //SF11 BW 125 kHz
-  RFM_Write(REG_FEI_LSB, 0xB4); //SF11 CRC On
-  RFM_Write(REG_FEI_MSB, 0x72); //125 kHz 4/5 coding rate explicit header mode
-  RFM_Write(REG_MODEM_CONFIG, 0x0C); //Low datarate optimization on AGC auto on
-#endif
-
-#ifdef SF10BW125         //SF10 BW 125 kHz
-  RFM_Write(REG_FEI_LSB, 0xA4); //SF10 CRC On
-  RFM_Write(REG_FEI_MSB, 0x72); //125 kHz 4/5 coding rate explicit header mode
-  RFM_Write(REG_MODEM_CONFIG, 0x04); //Low datarate optimization off AGC auto on
-#endif
-
-#ifdef SF9BW125          //SF9 BW 125 kHz
-  RFM_Write(REG_FEI_LSB, 0x94); //SF9 CRC On
-  RFM_Write(REG_FEI_MSB, 0x72); //125 kHz 4/5 coding rate explicit header mode
-  RFM_Write(REG_MODEM_CONFIG, 0x04); //Low datarate optimization off AGC auto on
-#endif
-
-#ifdef SF8BW125          //SF8 BW 125 kHz
-  RFM_Write(REG_FEI_LSB, 0x84); //SF8 CRC On
-  RFM_Write(REG_FEI_MSB, 0x72); //125 kHz 4/5 coding rate explicit header mode
-  RFM_Write(REG_MODEM_CONFIG, 0x04); //Low datarate optimization off AGC auto on
-#endif
-
-#ifdef SF7BW125          //SF7 BW 125 kHz
-  RFM_Write(REG_FEI_LSB, 0x74); //SF7 CRC On
-  RFM_Write(REG_FEI_MSB, 0x72); //125 kHz 4/5 coding rate explicit header mode
-  RFM_Write(REG_MODEM_CONFIG, 0x04); //Low datarate optimization off AGC auto on
-#endif
-
-#ifdef SF7BW250          //SF7 BW 250kHz
-  RFM_Write(REG_FEI_LSB, 0x74); //SF7 CRC On
-  RFM_Write(REG_FEI_MSB, 0x82); //250 kHz 4/5 coding rate explicit header mode
-  RFM_Write(REG_MODEM_CONFIG, 0x04); //Low datarate optimization off AGC auto on
-#endif 
+  /* Set RFM Datarate */
+  RFM_Write(REG_FEI_LSB, _sf);
+  RFM_Write(REG_FEI_MSB, _bw);
+  RFM_Write(REG_MODEM_CONFIG, _modemcfg);
 
   //Set payload length to the right length
   RFM_Write(0x22,Package_Length);

--- a/TinyLoRa.cpp
+++ b/TinyLoRa.cpp
@@ -48,7 +48,7 @@ static SPISettings RFM_spisettings = SPISettings(4000000, MSBFIRST, SPI_MODE0);
 */
 
 #ifdef AU915
-static const unsigned char PROGMEM TinyLoRa::LoRa_Frequency[8][3] = {
+const unsigned char PROGMEM TinyLoRa::LoRa_Frequency[8][3] = {
 	{ 0xE5, 0x33, 0x5A },	//Channel 0 916.800 MHz / 61.035 Hz = 15020890 = 0xE5335A
 	{ 0xE5, 0x40, 0x26 },	//Channel 2 917.000 MHz / 61.035 Hz = 15024166 = 0xE54026
 	{ 0xE5, 0x4C, 0xF3 },	//Channel 3 917.200 MHz / 61.035 Hz = 15027443 = 0xE54CF3
@@ -61,7 +61,7 @@ static const unsigned char PROGMEM TinyLoRa::LoRa_Frequency[8][3] = {
 #endif
 
 #ifdef EU863
-static const unsigned char PROGMEM TinyLoRa::LoRa_Frequency[8][3] = {
+const unsigned char PROGMEM TinyLoRa::LoRa_Frequency[8][3] = {
 	{ 0xD9, 0x06, 0x8B },	//Channel 0 868.100 MHz / 61.035 Hz = 14222987 = 0xD9068B
 	{ 0xD9, 0x13, 0x58 },	//Channel 1 868.300 MHz / 61.035 Hz = 14226264 = 0xD91358
 	{ 0xD9, 0x20, 0x24 },	//Channel 2 868.500 MHz / 61.035 Hz = 14229540 = 0xD92024
@@ -75,7 +75,7 @@ static const unsigned char PROGMEM TinyLoRa::LoRa_Frequency[8][3] = {
 #endif
 
 #ifdef US902
-static const unsigned char PROGMEM TinyLoRa::LoRa_Frequency[8][3] = {
+const unsigned char PROGMEM TinyLoRa::LoRa_Frequency[8][3] = {
 	{ 0xE1, 0xF9, 0xC0 },		//Channel 0 903.900 MHz / 61.035 Hz = 14809536 = 0xE1F9C0
 	{ 0xE2, 0x06, 0x8C },		//Channel 1 904.100 MHz / 61.035 Hz = 14812812 = 0xE2068C
 	{ 0xE2, 0x13, 0x59},		//Channel 2 904.300 MHz / 61.035 Hz = 14816089 = 0xE21359
@@ -88,7 +88,7 @@ static const unsigned char PROGMEM TinyLoRa::LoRa_Frequency[8][3] = {
 #endif
 
 #ifdef AS920
-static const unsigned char PROGMEM TinyLoRa::LoRa_Frequency[8][3] = {
+const unsigned char PROGMEM TinyLoRa::LoRa_Frequency[8][3] = {
 	{ 0xE6, 0xCC, 0xF4 },		//Channel 0 868.100 MHz / 61.035 Hz = 15125748 = 0xE6CCF4
 	{ 0xE6, 0xD9, 0xC0 },		//Channel 1 868.300 MHz / 61.035 Hz = 15129024 = 0xE6D9C0
 	{ 0xE6, 0x8C, 0xF3 },		//Channel 2 868.500 MHz / 61.035 Hz = 15109363 = 0xE68CF3
@@ -107,7 +107,7 @@ static const unsigned char PROGMEM TinyLoRa::LoRa_Frequency[8][3] = {
 *****************************************************************************************
 */
 
-static const unsigned char PROGMEM TinyLoRa::S_Table[16][16] = {
+const unsigned char PROGMEM TinyLoRa::S_Table[16][16] = {
 	  {0x63,0x7C,0x77,0x7B,0xF2,0x6B,0x6F,0xC5,0x30,0x01,0x67,0x2B,0xFE,0xD7,0xAB,0x76},
 	  {0xCA,0x82,0xC9,0x7D,0xFA,0x59,0x47,0xF0,0xAD,0xD4,0xA2,0xAF,0x9C,0xA4,0x72,0xC0},
 	  {0xB7,0xFD,0x93,0x26,0x36,0x3F,0xF7,0xCC,0x34,0xA5,0xE5,0xF1,0x71,0xD8,0x31,0x15},

--- a/TinyLoRa.cpp
+++ b/TinyLoRa.cpp
@@ -108,12 +108,6 @@ static const unsigned char PROGMEM TinyLoRa::S_Table[16][16] = {
 	  {0x8C,0xA1,0x89,0x0D,0xBF,0xE6,0x42,0x68,0x41,0x99,0x2D,0x0F,0xB0,0x54,0xBB,0x16}
 	};
 
-/*
-*****************************************************************************************
-* Description: Function used to initialize the RFM module on startup
-*****************************************************************************************
-*/
-
 /**************************************************************************/
 /*! 
     @brief Set the RFM channel.
@@ -126,51 +120,52 @@ void TinyLoRa::setChannel(rfm_channels_t channel)
   switch (channel)
   {
     case CH0:
-      _rfmLSB = 0xE1;
-      _rfmMID = 0xF9;
-      _rfmMSB = 0xC0;
+      Serial.println("Freq Test: ");
+      _rfmLSB = pgm_read_byte(&(LoRa_Frequency[0][0]));
+      _rfmMID = pgm_read_byte(&(LoRa_Frequency[0][1]));
+      _rfmMSB = pgm_read_byte(&(LoRa_Frequency[0][2]));
       _isMultiChan = 0;
       break;
     case CH1:
-      _rfmLSB = 0xE2;
-      _rfmMID = 0x06;
-      _rfmMSB = 0x8C;
+      _rfmLSB = pgm_read_byte(&(LoRa_Frequency[1][0]));
+      _rfmMID = pgm_read_byte(&(LoRa_Frequency[1][1]));
+      _rfmMSB = pgm_read_byte(&(LoRa_Frequency[1][2]));
       _isMultiChan = 0;
       break;
     case CH2:
-      _rfmLSB = 0xE2;
-      _rfmMID = 0x13;
-      _rfmMSB = 0x59;
+      _rfmLSB = pgm_read_byte(&(LoRa_Frequency[2][0]));
+      _rfmMID = pgm_read_byte(&(LoRa_Frequency[2][1]));
+      _rfmMSB = pgm_read_byte(&(LoRa_Frequency[2][2]));
       _isMultiChan = 0;
       break;
     case CH3:
-      _rfmLSB = 0xE2;
-      _rfmMID = 0x20;
-      _rfmMSB = 0x26;
+      _rfmLSB = pgm_read_byte(&(LoRa_Frequency[3][0]));
+      _rfmMID = pgm_read_byte(&(LoRa_Frequency[3][1]));
+      _rfmMSB = pgm_read_byte(&(LoRa_Frequency[3][2]));
       _isMultiChan = 0;
       break;
     case CH4:
-      _rfmLSB = 0xE2;
-      _rfmMID = 0x2C;
-      _rfmMSB = 0xF3;
+      _rfmLSB = pgm_read_byte(&(LoRa_Frequency[4][0]));
+      _rfmMID = pgm_read_byte(&(LoRa_Frequency[4][1]));
+      _rfmMSB = pgm_read_byte(&(LoRa_Frequency[4][2]));
       _isMultiChan = 0;
       break;
     case CH5:
-      _rfmLSB = 0xE2;
-      _rfmMID = 0x39;
-      _rfmMSB = 0xC0;
+      _rfmLSB = pgm_read_byte(&(LoRa_Frequency[5][0]));
+      _rfmMID = pgm_read_byte(&(LoRa_Frequency[5][1]));
+      _rfmMSB = pgm_read_byte(&(LoRa_Frequency[5][2]));
       _isMultiChan = 0;
       break;
     case CH6:
-      _rfmLSB = 0xE2;
-      _rfmMID = 0x46;
-      _rfmMSB = 0x8C;
+      _rfmLSB = pgm_read_byte(&(LoRa_Frequency[6][0]));
+      _rfmMID = pgm_read_byte(&(LoRa_Frequency[6][1]));
+      _rfmMSB = pgm_read_byte(&(LoRa_Frequency[6][2]));
       _isMultiChan = 0;
       break;
     case CH7:
-      _rfmLSB = 0xE2;
-      _rfmMID = 0x53;
-      _rfmMSB = 0x59;
+      _rfmLSB = pgm_read_byte(&(LoRa_Frequency[7][0]));
+      _rfmMID = pgm_read_byte(&(LoRa_Frequency[7][1]));
+      _rfmMSB = pgm_read_byte(&(LoRa_Frequency[7][2]));
       _isMultiChan = 0;
       break;
     case MULTI:
@@ -193,6 +188,11 @@ TinyLoRa::TinyLoRa(int8_t rfm__irq, int8_t rfm_nss) {
   _cs = rfm_nss;
 }
 
+/*
+*****************************************************************************************
+* Description: Function used to initialize the RFM module on startup
+*****************************************************************************************
+*/
 void TinyLoRa::begin() 
 {
 
@@ -270,29 +270,16 @@ void TinyLoRa::RFM_Send_Package(unsigned char *RFM_Tx_Package, unsigned char Pac
   //Switch _irq to TxDone
   RFM_Write(0x40,0x40);
 
+  // Select which channel to send data on 
   if (_isMultiChan == 1) {
-    Serial.println("Multi Channel enabled");
     RFM_Write(RegFrfMsb, pgm_read_byte(&(LoRa_Frequency[randomNum][0])));
     RFM_Write(RegFrfMid, pgm_read_byte(&(LoRa_Frequency[randomNum][1])));
     RFM_Write(RegFrfLsb, pgm_read_byte(&(LoRa_Frequency[randomNum][2])));
   } else {
-    Serial.println("Single Channel enabled");
     RFM_Write(RegFrfMsb, _rfmMSB);
     RFM_Write(RegFrfMid, _rfmMID);
     RFM_Write(RegFrfLsb, _rfmLSB);
   }
-
-// #ifdef SGLCH
-//   RFM_Write(RegFrfMsb, _rfmMSB);
-//   RFM_Write(RegFrfMid, _rfmMID);
-//   RFM_Write(RegFrfLsb, _rfmLSB);
-// #endif
-
-// #ifdef MULTICH
-//   RFM_Write(RegFrfMsb, pgm_read_byte(&(LoRa_Frequency[randomNum][0])));
-//   RFM_Write(RegFrfMid, pgm_read_byte(&(LoRa_Frequency[randomNum][1])));
-//   RFM_Write(RegFrfLsb, pgm_read_byte(&(LoRa_Frequency[randomNum][2])));
-// #endif
 
 #ifdef SF12BW125         //SF12 BW 125 kHz
   RFM_Write(0x1E, 0xC4); //SF12 CRC On

--- a/TinyLoRa.cpp
+++ b/TinyLoRa.cpp
@@ -114,6 +114,60 @@ static const unsigned char PROGMEM TinyLoRa::S_Table[16][16] = {
 *****************************************************************************************
 */
 
+/**************************************************************************/
+/*! 
+    @brief Set the single-channel to send
+    @param channel Which channel to send data on
+*/
+/**************************************************************************/
+void TinyLoRa::setChannel(rfm_channels_t channel)
+{
+  _rfmMSB, _rfmLSB, _rfmMID = 0;
+  switch (channel)
+  {
+    case CH0:
+      _rfmLSB = 0xE1;
+      _rfmMID = 0xF9;
+      _rfmMSB = 0xC0;
+      break;
+    case CH1:
+      _rfmLSB = 0xE2;
+      _rfmMID = 0x06;
+      _rfmMSB = 0x8C;
+      break;
+    case CH2:
+      _rfmLSB = 0xE2;
+      _rfmMID = 0x13;
+      _rfmMSB = 0x59;
+      break;
+    case CH3:
+      _rfmLSB = 0xE2;
+      _rfmMID = 0x20;
+      _rfmMSB = 0x26;
+      break;
+    case CH4:
+      _rfmLSB = 0xE2;
+      _rfmMID = 0x2C;
+      _rfmMSB = 0xF3;
+      break;
+    case CH5:
+      _rfmLSB = 0xE2;
+      _rfmMID = 0x39;
+      _rfmMSB = 0xC0;
+    case CH6:
+      _rfmLSB = 0xE2;
+      _rfmMID = 0x46;
+      _rfmMSB = 0x8C;
+  }
+}
+
+/**************************************************************************/
+/*! 
+    @brief constructor initializes provided pin values
+    @param rfm_irq interrupt pin (rfm_nss)
+    @parm rfm_nss ss pin (rfm_nss)
+*/
+/**************************************************************************/
 TinyLoRa::TinyLoRa(int8_t rfm__irq, int8_t rfm_nss) {
   _irq = rfm__irq;
   _cs = rfm_nss;
@@ -199,14 +253,12 @@ void TinyLoRa::RFM_Send_Package(unsigned char *RFM_Tx_Package, unsigned char Pac
 // Single Channel Send on CH6, 903.9MHz
 // 0xE1, 0xF9, 0xC0
 #ifdef SGLCH
-  RFM_Write(RegFrfMsb, 0xE1);
-  RFM_Write(RegFrfMid, 0xF9);
-  RFM_Write(RegFrfLsb, 0xC0);
+  RFM_Write(RegFrfMsb, _rfmMSB);
+  RFM_Write(RegFrfMid, _rfmMID);
+  RFM_Write(RegFrfLsb, _rfmLSB);
 #endif
 
 #ifdef MULTICH
-  // change the channel of the RFM module
-  // br: carrier freq split between 0x06, 0x07, 0x08
   RFM_Write(RegFrfMsb, pgm_read_byte(&(LoRa_Frequency[randomNum][0])));
   RFM_Write(RegFrfMid, pgm_read_byte(&(LoRa_Frequency[randomNum][1])));
   RFM_Write(RegFrfLsb, pgm_read_byte(&(LoRa_Frequency[randomNum][2])));

--- a/TinyLoRa.h
+++ b/TinyLoRa.h
@@ -5,10 +5,29 @@
 #include <avr/pgmspace.h>
 
 // debugging, unset if you don't need this.
-//#define DEBUG
+#define DEBUG
 
 // Multi-Channel Package Sending (default)
-#define MULTICH
+//#define MULTICH
+#define SGLCH
+
+/**************************************************************************/
+/*! 
+    @brief  RFM Channel List
+*/
+/**************************************************************************/
+typedef enum rfm_channels
+{
+  CH0,
+  CH1,
+  CH2,
+  CH3,
+  CH4,
+  CH5,
+  CH6,
+  CH7,
+  MUTLI,
+} rfm_channels_t;
 
 /* TTN Configuration */
 // Set TTN frequecy plan EU863, AU915, AS920, US902
@@ -45,14 +64,16 @@ class TinyLoRa
 	public:
 		uint8_t txrandomNum;
 		uint16_t frameCounter;
-		TinyLoRa(int8_t rfm_dio0, int8_t rfm_nss);
+    void setChannel(rfm_channels_t channel);
+    TinyLoRa(int8_t rfm_dio0, int8_t rfm_nss);
 		void begin(void);
 		void sendData(unsigned char *Data, unsigned char Data_Length, unsigned int Frame_Counter_Tx);
 
 	private:
 		uint8_t randomNum;
 		int8_t _cs, _irq;
-		static const unsigned char LoRa_Frequency[8][3];
+    unsigned char _rfmMSB, _rfmMID, _rfmLSB;
+    static const unsigned char LoRa_Frequency[8][3];
 		static const unsigned char S_Table[16][16];
 		void RFM_Send_Package(unsigned char *RFM_Tx_Package, unsigned char Package_Length);
 		void RFM_Write(unsigned char RFM_Address, unsigned char RFM_Data);

--- a/TinyLoRa.h
+++ b/TinyLoRa.h
@@ -1,3 +1,25 @@
+/*!
+ * @file TinyLoRa.h
+ *
+ * This is part of Adafruit's TinyLoRa library for the Arduino platform. It is
+ * designed specifically to work with the Adafruit Feather 32u4 RFM95 LoRa:
+ * https://www.adafruit.com/product/3078
+ *
+ * This library uses SPI to communicate, 4 pins (SCL, SDA, IRQ, SS)
+ * are required to interface with the HopeRF RFM95/96 breakout.
+ *
+ * Adafruit invests time and resources providing this open source code,
+ * please support Adafruit and open-source hardware by purchasing
+ * products from Adafruit!
+ *
+ * Copyright 2015, 2016 Ideetron B.V.
+ * Modified by Brent Rubell for Adafruit Industries.
+ *
+ *
+ * BSD license, all text here must be included in any redistribution.
+ *
+ */
+
 #ifndef TINY_LORA_H
 #define TINY_LORA_H
 
@@ -7,11 +29,7 @@
 // uncomment for debug output
 // #define DEBUG
 
-/**************************************************************************/
-/*! 
-    @brief RFM Channel List
-*/
-/**************************************************************************/
+/** RFM channel options */
 typedef enum rfm_channels
 {
   CH0,
@@ -25,11 +43,7 @@ typedef enum rfm_channels
   MULTI,
 } rfm_channels_t;
 
-/**************************************************************************/
-/*! 
-    @brief RFM Datarate List
-*/
-/**************************************************************************/
+/** RFM fixed datarate, dependent on region */
 typedef enum rfm_datarates
 {
   SF7BW125,
@@ -41,32 +55,39 @@ typedef enum rfm_datarates
   SF12BW125,
 } rfm_datarates_t;
 
-// TTN region configuration
-#define US902
+/** Region configuration*/
+#define US902 ///< Used in USA, Canada and South America
+//#define EU863 ///< Used in Europe
+//#define AU915 ///< Used in Australia
+//#define AS920 ///< Used in Asia
 
 /* RFM Modes */
-#define MODE_SLEEP  0x00
-#define MODE_LORA   0x80
-#define MODE_STDBY  0x01
-#define MODE_TX     0x83
+#define MODE_SLEEP  0x00  ///<low-power mode
+#define MODE_LORA   0x80  ///<LoRa operating mode
+#define MODE_STDBY  0x01  ///<Osc. and baseband disabled
+#define MODE_TX     0x83  ///<Configures and transmits packet
 
 /* RFM Registers */
-#define REG_PA_CONFIG              0x09
-#define REG_PREAMBLE_MSB           0x20
-#define REG_PREAMBLE_LSB           0x21
-#define REG_FRF_MSB                0x06
-#define REG_FRF_MID                0x07
-#define REG_FRF_LSB                0x08
-#define REG_FEI_LSB                0x1E
-#define REG_FEI_MSB                0x1D
-#define REG_MODEM_CONFIG           0x26
+#define REG_PA_CONFIG              0x09 ///<PA selection and Output Power control
+#define REG_PREAMBLE_MSB           0x20 ///<Preamble Length, MSB
+#define REG_PREAMBLE_LSB           0x21 ///<Preamble Length, LSB
+#define REG_FRF_MSB                0x06 ///<RF Carrier Frequency MSB
+#define REG_FRF_MID                0x07 ///<RF Carrier Frequency Intermediate
+#define REG_FRF_LSB                0x08 ///<RF Carrier Frequency LSB
+#define REG_FEI_LSB                0x1E ///<Info from Prev. Header
+#define REG_FEI_MSB                0x1D ///<Number of received bytes
+#define REG_MODEM_CONFIG           0x26 ///<Modem configuration register
 
-/* TinyLoRa Class */
+/**************************************************************************/
+/*! 
+    @brief  TinyLoRa Class
+*/
+/**************************************************************************/
 class TinyLoRa
 {
 	public:
-		uint8_t txrandomNum;
-		uint16_t frameCounter;
+		uint8_t txrandomNum;  ///<random number for AES
+		uint16_t frameCounter;  ///<frame counter
     void setChannel(rfm_channels_t channel);
     void setDatarate(rfm_datarates_t datarate);
     TinyLoRa(int8_t rfm_dio0, int8_t rfm_nss);

--- a/TinyLoRa.h
+++ b/TinyLoRa.h
@@ -26,7 +26,7 @@ typedef enum rfm_channels
   CH5,
   CH6,
   CH7,
-  MUTLI,
+  MULTI,
 } rfm_channels_t;
 
 /* TTN Configuration */
@@ -72,6 +72,7 @@ class TinyLoRa
 	private:
 		uint8_t randomNum;
 		int8_t _cs, _irq;
+    bool _isMultiChan;
     unsigned char _rfmMSB, _rfmMID, _rfmLSB;
     static const unsigned char LoRa_Frequency[8][3];
 		static const unsigned char S_Table[16][16];

--- a/TinyLoRa.h
+++ b/TinyLoRa.h
@@ -25,16 +25,24 @@ typedef enum rfm_channels
   MULTI,
 } rfm_channels_t;
 
-/* TTN Configuration */
+/**************************************************************************/
+/*! 
+    @brief RFM Datarate List
+*/
+/**************************************************************************/
+typedef enum rfm_datarates
+{
+  SF7BW125,
+  SF7BW250,
+  SF8BW125,
+  SF9BW125,
+  SF10BW125,
+  SF11BW125,
+  SF12BW125,
+} rfm_datarates_t;
+
+// TTN region configuration
 #define US902
-// Define fixed datarate
-#define SF7BW125
-//#define SF12BW125
-//#define SF11BW125
-//#define SF10BW125
-//#define SF9BW125
-//#define SF8BW125
-//#define SF7BW250
 
 /* RFM Modes */
 #define MODE_SLEEP  0x00
@@ -60,6 +68,7 @@ class TinyLoRa
 		uint8_t txrandomNum;
 		uint16_t frameCounter;
     void setChannel(rfm_channels_t channel);
+    void setDatarate(rfm_datarates_t datarate);
     TinyLoRa(int8_t rfm_dio0, int8_t rfm_nss);
 		void begin(void);
 		void sendData(unsigned char *Data, unsigned char Data_Length, unsigned int Frame_Counter_Tx);
@@ -68,7 +77,7 @@ class TinyLoRa
 		uint8_t randomNum;
 		int8_t _cs, _irq;
     bool _isMultiChan;
-    unsigned char _rfmMSB, _rfmMID, _rfmLSB;
+    unsigned char _rfmMSB, _rfmMID, _rfmLSB, _sf, _bw, _modemcfg;
     static const unsigned char LoRa_Frequency[8][3];
 		static const unsigned char S_Table[16][16];
 		void RFM_Send_Package(unsigned char *RFM_Tx_Package, unsigned char Package_Length);

--- a/TinyLoRa.h
+++ b/TinyLoRa.h
@@ -30,11 +30,7 @@ typedef enum rfm_channels
 } rfm_channels_t;
 
 /* TTN Configuration */
-// Set TTN frequecy plan EU863, AU915, AS920, US902
 #define US902
-//#define EU863
-//#define AU915
-//#define AS920
 // Define fixed datarate
 #define SF7BW125
 //#define SF12BW125

--- a/TinyLoRa.h
+++ b/TinyLoRa.h
@@ -7,13 +7,9 @@
 // debugging, unset if you don't need this.
 #define DEBUG
 
-// Multi-Channel Package Sending (default)
-//#define MULTICH
-#define SGLCH
-
 /**************************************************************************/
 /*! 
-    @brief  RFM Channel List
+    @brief RFM Channel List
 */
 /**************************************************************************/
 typedef enum rfm_channels
@@ -47,12 +43,15 @@ typedef enum rfm_channels
 #define MODE_TX     0x83
 
 /* RFM Registers */
-#define REG_PA_CONFIG            0x09
-#define REG_PREAMBLE_MSB         0x20
-#define REG_PREAMBLE_LSB         0x21
-#define RegFrfMsb                0x06
-#define RegFrfMid                0x07
-#define RegFrfLsb                0x08
+#define REG_PA_CONFIG              0x09
+#define REG_PREAMBLE_MSB           0x20
+#define REG_PREAMBLE_LSB           0x21
+#define REG_FRF_MSB                0x06
+#define REG_FRF_MID                0x07
+#define REG_FRF_LSB                0x08
+#define REG_FEI_LSB                0x1E
+#define REG_FEI_MSB                0x1D
+#define REG_MODEM_CONFIG           0x26
 
 /* TinyLoRa Class */
 class TinyLoRa

--- a/TinyLoRa.h
+++ b/TinyLoRa.h
@@ -4,8 +4,8 @@
 #include <Arduino.h>
 #include <avr/pgmspace.h>
 
-// debugging, unset if you don't need this.
-#define DEBUG
+// uncomment for debug output
+// #define DEBUG
 
 /**************************************************************************/
 /*! 

--- a/examples/hello_LoRa/hello_LoRa.ino
+++ b/examples/hello_LoRa/hello_LoRa.ino
@@ -1,4 +1,4 @@
-// Hello LoRa - ABP TTN Packet Sender
+// Hello LoRa - ABP TTN Packet Sender (Multi-Channel)
 // Tutorial Link: https://learn.adafruit.com/the-things-network-for-feather/using-a-feather-32u4
 //
 // Adafruit invests time and resources providing this open source code.
@@ -42,6 +42,10 @@ void setup()
   
   // Initialize LoRa
   Serial.println("Starting LoRa...");
+  // define multi-channel sending
+  lora.setChannel(MULTI);
+  // set datarate
+  lora.setDatarate(SF7BW125);
   lora.begin();
 }
 

--- a/examples/hello_LoRa_single_chan/hello_LoRa_single_chan.ino
+++ b/examples/hello_LoRa_single_chan/hello_LoRa_single_chan.ino
@@ -44,6 +44,8 @@ void setup()
   Serial.println("Starting LoRa...");
   // define channel to send data on
   lora.setChannel(CH2);
+  // set datarate
+  lora.setDatarate(SF7BW125);
   lora.begin();
 }
 

--- a/examples/hello_LoRa_single_chan/hello_LoRa_single_chan.ino
+++ b/examples/hello_LoRa_single_chan/hello_LoRa_single_chan.ino
@@ -1,0 +1,64 @@
+// Hello LoRa Single Channel - ABP TTN Single Channel Packet Sender
+// Tutorial Link: https://learn.adafruit.com/the-things-network-for-feather/using-a-feather-32u4
+//
+// Adafruit invests time and resources providing this open source code.
+// Please support Adafruit and open source hardware by purchasing
+// products from Adafruit!
+//
+// Written by Brent Rubell for Adafruit Industries
+// Copyright 2018 Adafruit Industries
+// Copyright 2015, 2016 Ideetron B.V.
+/************************** Configuration ***********************************/
+#include <TinyLoRa.h>
+#include <SPI.h>
+
+// Network Session Key (MSB)
+uint8_t NwkSkey[16] = { FILL_THIS_IN };
+
+// Application Session Key (MSB)
+uint8_t AppSkey[16] = { FILL_THIS_IN };
+
+// Device Address (MSB)
+uint8_t DevAddr[4] = { FILL_THIS_IN };
+
+/************************** Example Begins Here ***********************************/
+// Data Packet to Send to TTN
+unsigned char loraData[11] = {"hello LoRa"};
+
+// How many times data transfer should occur, in seconds
+const unsigned int sendInterval = 15;
+
+// LoRa Object - (RFM DIO0, RFM NSS)
+TinyLoRa lora = TinyLoRa(7, 8);
+
+void setup()
+{
+  delay(2000);
+  while (! Serial);
+  Serial.begin(9600);
+ 
+  // Initialize pin LED_BUILTIN as an output
+  pinMode(LED_BUILTIN, OUTPUT);
+  
+  // Initialize LoRa
+  Serial.println("Starting LoRa...");
+  // define channel to send data on
+  lora.setChannel(CH2);
+  lora.begin();
+}
+
+void loop()
+{
+  Serial.println("Sending LoRa Data...");
+  lora.sendData(loraData, sizeof(loraData), lora.frameCounter);
+  Serial.print("Frame Counter: ");Serial.println(lora.frameCounter);
+  lora.frameCounter++;
+
+  // blink LED to indicate packet sent
+  digitalWrite(LED_BUILTIN, HIGH);
+  delay(1000);
+  digitalWrite(LED_BUILTIN, LOW);
+  
+  Serial.println("delaying...");
+  delay(sendInterval * 1000);
+}


### PR DESCRIPTION
Adding support for setting single channel (CH1, CH2, ...) and multi-channel (MULTI) using `lora.setChannel()`

Adding support for setting the data-rate (spreading factor, bandwidth, modem configuration) using `lora.setDataRate()`

Tested on Feather 32U4

Addressing: https://github.com/adafruit/TinyLoRa/issues/6