### PR TITLE
Really set the pinmode of _irq pin to INPUT

### DIFF
--- a/TinyLoRa.cpp
+++ b/TinyLoRa.cpp
@@ -298,7 +298,7 @@ bool TinyLoRa::begin()
   pinMode(_cs, OUTPUT);
 
   // RFM95 _irq as input
-  pinMode(_irq, OUTPUT);
+  pinMode(_irq, INPUT);
 
   uint8_t ver = RFM_Read(0x42);
   if(ver!=18){


### PR DESCRIPTION
Pinmode was obviously set wrong.

Have used the original code on an UNO and also on an ATmega328p on a breadbord with RFM95 module. Lora messages were sent and successfully received on the other end, but afterwards it would hang in the while loop reading the _irq pin at the end of RFM_Send_Package().

The high _irq pin (DIO0 on RFM95) wasn't being registered by digitalRead() and the current of the pin was sunk.