### PR TITLE
Add parameters to change pin assignment in begin function

### DIFF
--- a/TinyLoRa.cpp
+++ b/TinyLoRa.cpp
@@ -288,11 +288,11 @@ TinyLoRa::TinyLoRa(int8_t rfm_irq, int8_t rfm_nss) {
      @return True if the RFM has been initialized
  */
  /**************************************************************************/
-bool TinyLoRa::begin() 
+bool TinyLoRa::begin(int8_t sck, int8_t miso, int8_t mosi) 
 {
 
   // start and configure SPI
-  SPI.begin();
+  SPI.begin(sck,miso,mosi);
   
   // RFM95 ss as output
   pinMode(_cs, OUTPUT);

--- a/TinyLoRa.h
+++ b/TinyLoRa.h
@@ -104,7 +104,7 @@ class TinyLoRa
     void setChannel(rfm_channels_t channel);
     void setDatarate(rfm_datarates_t datarate);
     TinyLoRa(int8_t rfm_dio0, int8_t rfm_nss);
-		bool begin(void);
+		bool begin(int8_t sck=-1, int8_t miso=-1, int8_t mosi=-1);
 		void sendData(unsigned char *Data, unsigned char Data_Length, unsigned int Frame_Counter_Tx);
 
 	private:


### PR DESCRIPTION
To allow this library to be used with other pin configurations I added parameters for the SPI pins.
By using default parameters, the library is still fully compatible.


