### PR TITLE
Add RST to init

### DIFF
--- a/TinyLoRa.cpp
+++ b/TinyLoRa.cpp
@@ -304,20 +304,19 @@ bool TinyLoRa::begin()
   // RFM _irq as input
   pinMode(_irq, INPUT);
 
-  if (_rst < 0)
-    return 0;
+  if (_rst > 0){
+    // RFM _rst as output
+    pinMode(_rst, OUTPUT);
 
-  // RFM _rst as output
-  pinMode(_rst, OUTPUT);
+    // Reset the RFM radio module
+    digitalWrite(_rst, LOW);
 
-  // Reset the RFM radio module
-  digitalWrite(_rst, LOW);
+    delay(0.1);
 
-  delay(0.1);
+    digitalWrite(_rst, HIGH);
 
-  digitalWrite(_rst, HIGH);
-
-  delay(5);
+    delay(5);
+  }
 
   // Reset the radio module on init
 

--- a/TinyLoRa.cpp
+++ b/TinyLoRa.cpp
@@ -275,7 +275,7 @@ void TinyLoRa::setChannel(rfm_channels_t channel) {
               The RFM module's reset pin (rfm_rst).
 */
 /**************************************************************************/
-TinyLoRa::TinyLoRa(uint8_t rfm_irq, uint8_t rfm_nss, uint8_t rfm_rst) {
+TinyLoRa::TinyLoRa(int8_t rfm_irq, int8_t rfm_nss, int8_t rfm_rst) {
   _irq = rfm_irq;
   _cs = rfm_nss;
   _rst = rfm_rst;
@@ -303,6 +303,9 @@ bool TinyLoRa::begin()
 
   // RFM _irq as input
   pinMode(_irq, INPUT);
+
+  if (_rst < 0)
+    return 0;
 
   // RFM _rst as output
   pinMode(_rst, OUTPUT);

--- a/TinyLoRa.h
+++ b/TinyLoRa.h
@@ -74,6 +74,8 @@ typedef enum rfm_datarates
 //#define AU915 ///< Used in Australia
 //#define AS920 ///< Used in Asia
 
+#define RFM9x_VER   0x12 ///<Expected RFM9x RegVersion
+
 /* RFM Modes */
 #define MODE_SLEEP  0x00  ///<low-power mode
 #define MODE_LORA   0x80  ///<LoRa operating mode
@@ -90,6 +92,7 @@ typedef enum rfm_datarates
 #define REG_FEI_LSB                0x1E ///<Info from Prev. Header
 #define REG_FEI_MSB                0x1D ///<Number of received bytes
 #define REG_MODEM_CONFIG           0x26 ///<Modem configuration register
+#define REG_VER                    0x42 ///<RFM9x version register
 
 /**************************************************************************/
 /*! 
@@ -103,13 +106,13 @@ class TinyLoRa
 		uint16_t frameCounter;  ///<frame counter
     void setChannel(rfm_channels_t channel);
     void setDatarate(rfm_datarates_t datarate);
-    TinyLoRa(int8_t rfm_dio0, int8_t rfm_nss);
+    TinyLoRa(uint8_t rfm_dio0, uint8_t rfm_nss, uint8_t rfm_rst);
 		bool begin(void);
 		void sendData(unsigned char *Data, unsigned char Data_Length, unsigned int Frame_Counter_Tx);
 
 	private:
 		uint8_t randomNum;
-		int8_t _cs, _irq;
+		uint8_t _cs, _irq, _rst;
     bool _isMultiChan;
     unsigned char _rfmMSB, _rfmMID, _rfmLSB, _sf, _bw, _modemcfg;
     static const unsigned char LoRa_Frequency[8][3];

--- a/TinyLoRa.h
+++ b/TinyLoRa.h
@@ -106,13 +106,13 @@ class TinyLoRa
 		uint16_t frameCounter;  ///<frame counter
     void setChannel(rfm_channels_t channel);
     void setDatarate(rfm_datarates_t datarate);
-    TinyLoRa(uint8_t rfm_dio0, uint8_t rfm_nss, uint8_t rfm_rst);
+    TinyLoRa(int8_t rfm_dio0, int8_t rfm_nss, int8_t rfm_rst);
 		bool begin(void);
 		void sendData(unsigned char *Data, unsigned char Data_Length, unsigned int Frame_Counter_Tx);
 
 	private:
 		uint8_t randomNum;
-		uint8_t _cs, _irq, _rst;
+		int8_t _cs, _irq, _rst;
     bool _isMultiChan;
     unsigned char _rfmMSB, _rfmMID, _rfmLSB, _sf, _bw, _modemcfg;
     static const unsigned char LoRa_Frequency[8][3];

--- a/examples/hello_LoRa/hello_LoRa.ino
+++ b/examples/hello_LoRa/hello_LoRa.ino
@@ -32,10 +32,10 @@ unsigned char loraData[11] = {"hello LoRa"};
 const unsigned int sendInterval = 30;
 
 // Pinout for Adafruit Feather 32u4 LoRa
-TinyLoRa lora = TinyLoRa(7, 8);
+TinyLoRa lora = TinyLoRa(7, 8, 4);
 
 // Pinout for Adafruit Feather M0 LoRa
-//TinyLoRa lora = TinyLoRa(3, 8);
+//TinyLoRa lora = TinyLoRa(3, 8, 4);
 
 void setup()
 {

--- a/examples/hello_LoRa_single_chan/hello_LoRa_single_chan.ino
+++ b/examples/hello_LoRa_single_chan/hello_LoRa_single_chan.ino
@@ -32,10 +32,10 @@ unsigned char loraData[11] = {"hello LoRa"};
 const unsigned int sendInterval = 30;
 
 // Pinout for Feather 32u4 LoRa
-TinyLoRa lora = TinyLoRa(7, 8);
+TinyLoRa lora = TinyLoRa(7, 8, 4);
 
 // Pinout for Feather M0 LoRa
-//TinyLoRa lora = TinyLoRa(3, 8);
+//TinyLoRa lora = TinyLoRa(3, 8, 4);
 
 void setup()
 {

--- a/examples/tinylora_dht22/tinylora_dht22.ino
+++ b/examples/tinylora_dht22/tinylora_dht22.ino
@@ -33,10 +33,10 @@ unsigned char loraData[4];
 const unsigned int sendInterval = 30;
 
 // Pinout for Adafruit Feather 32u4 LoRa
-TinyLoRa lora = TinyLoRa(7, 8);
+TinyLoRa lora = TinyLoRa(7, 8, 4);
 
 // Pinout for Adafruit Feather M0 LoRa
-//TinyLoRa lora = TinyLoRa(3, 8);
+//TinyLoRa lora = TinyLoRa(3, 8, 4);
 
 // pin the DHT22 is connected to
 #define DHTPIN 10

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TinyLoRa
-version=1.0.5
+version=1.1
 author=Adafruit
 maintainer=Adafruit<info@adafruit.com>
 sentence=Tiny LoRa Library for TTN


### PR DESCRIPTION
Resets the RFM9x module before attempting to read the RFM9x `RegVersion`. Prevents chip from starting/reading in bad state. Examples modified to reflect the addition of the RST pin. 

Tested on Feather M0 Radio with >500 successful continuous TX's to a TheThingsNetwork Gateway.

