### PR TITLE
Removed extra M0 pinout example

### DIFF
--- a/examples/tinylora_dht22/tinylora_dht22.ino
+++ b/examples/tinylora_dht22/tinylora_dht22.ino
@@ -42,9 +42,6 @@ TinyLoRa lora = TinyLoRa(7, 8, 4);
 #define DHTPIN 10
 DHT dht(DHTPIN, DHT22);
 
-// Pinout for Adafruit Feather M0 LoRa
-//TinyLoRa lora = TinyLoRa(3, 8);
-
 void setup()
 {
   delay(2000);

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TinyLoRa
-version=1.1
+version=1.1.1
 author=Adafruit
 maintainer=Adafruit<info@adafruit.com>
 sentence=Tiny LoRa Library for TTN


### PR DESCRIPTION
Found an extra pinout example for the Feather M0 in the DHT example, just removed it. 