### PR TITLE
Add txpower and frame port support to TinyLoRa. Modify only one example.

### DIFF
--- a/TinyLoRa.cpp
+++ b/TinyLoRa.cpp
@@ -531,7 +531,6 @@ void TinyLoRa::sendData(unsigned char *Data, unsigned char Data_Length, unsigned
   unsigned char Mac_Header = 0x40;
 
   unsigned char Frame_Control = 0x00;
-// TODO Do we need this?  unsigned char Frame_Port;
 
   //make a copy of Data
   unsigned char tmpData[Data_Length];

--- a/TinyLoRa.cpp
+++ b/TinyLoRa.cpp
@@ -51,6 +51,8 @@
 extern uint8_t NwkSkey[16]; ///< Network Session Key
 extern uint8_t AppSkey[16]; ///< Application Session Key
 extern uint8_t DevAddr[4]; ///< Device Address
+extern uint8_t Tx_Power; ///< Tx power
+extern uint8_t Frame_Port; ///< Frame Port
 
 static SPISettings RFM_spisettings = SPISettings(4000000, MSBFIRST, SPI_MODE0);
 
@@ -91,7 +93,7 @@ const unsigned char PROGMEM TinyLoRa::LoRa_Frequency[8][3] = {
 const unsigned char PROGMEM TinyLoRa::LoRa_Frequency[8][3] = {
 	{ 0xE1, 0xF9, 0xC0 },		//Channel 0 903.900 MHz / 61.035 Hz = 14809536 = 0xE1F9C0
 	{ 0xE2, 0x06, 0x8C },		//Channel 1 904.100 MHz / 61.035 Hz = 14812812 = 0xE2068C
-	{ 0xE2, 0x13, 0x59},		//Channel 2 904.300 MHz / 61.035 Hz = 14816089 = 0xE21359
+	{ 0xE2, 0x13, 0x59 },		//Channel 2 904.300 MHz / 61.035 Hz = 14816089 = 0xE21359
 	{ 0xE2, 0x20, 0x26 },		//Channel 3 904.500 MHz / 61.035 Hz = 14819366 = 0xE22026
 	{ 0xE2, 0x2C, 0xF3 },		//Channel 4 904.700 MHz / 61.035 Hz = 14822643 = 0xE22CF3
 	{ 0xE2, 0x39, 0xC0 },		//Channel 5 904.900 MHz / 61.035 Hz = 14825920 = 0xE239C0
@@ -292,7 +294,7 @@ TinyLoRa::TinyLoRa(int8_t rfm_irq, int8_t rfm_nss, int8_t rfm_rst) {
      @return True if the RFM has been initialized
  */
  /**************************************************************************/
-bool TinyLoRa::begin() 
+bool TinyLoRa::begin(unsigned char Tx_Power) 
 {
 
   // start and configure SPI
@@ -331,7 +333,7 @@ bool TinyLoRa::begin()
   RFM_Write(0x01,MODE_LORA);
 
   //PA pin (maximal power)
-  RFM_Write(0x09,0xFF);
+  RFM_Write(0x09,Tx_Power);
 
   //Rx Timeout set to 37 symbols
   RFM_Write(0x1F,0x25);
@@ -502,7 +504,7 @@ uint8_t TinyLoRa::RFM_Read(uint8_t RFM_Address) {
               Length of data to be sent.
 */
 /**************************************************************************/
-void TinyLoRa::sendData(unsigned char *Data, unsigned char Data_Length, unsigned int Frame_Counter_Tx)
+void TinyLoRa::sendData(unsigned char *Data, unsigned char Data_Length, unsigned int Frame_Counter_Tx, unsigned char Frame_Port)
 {
   
   //Define variables
@@ -520,7 +522,7 @@ void TinyLoRa::sendData(unsigned char *Data, unsigned char Data_Length, unsigned
   unsigned char Mac_Header = 0x40;
 
   unsigned char Frame_Control = 0x00;
-  unsigned char Frame_Port = 0x01;
+//  unsigned char Frame_Port = 0x01;
 
   //make a copy of Data
   unsigned char tmpData[Data_Length];

--- a/TinyLoRa.cpp
+++ b/TinyLoRa.cpp
@@ -51,8 +51,6 @@
 extern uint8_t NwkSkey[16]; ///< Network Session Key
 extern uint8_t AppSkey[16]; ///< Application Session Key
 extern uint8_t DevAddr[4]; ///< Device Address
-extern uint8_t Tx_Power; ///< Tx power
-extern uint8_t Frame_Port; ///< Frame Port
 
 static SPISettings RFM_spisettings = SPISettings(4000000, MSBFIRST, SPI_MODE0);
 
@@ -294,7 +292,7 @@ TinyLoRa::TinyLoRa(int8_t rfm_irq, int8_t rfm_nss, int8_t rfm_rst) {
      @return True if the RFM has been initialized
  */
  /**************************************************************************/
-bool TinyLoRa::begin(unsigned char Tx_Power) 
+bool TinyLoRa::begin()
 {
 
   // start and configure SPI
@@ -332,9 +330,6 @@ bool TinyLoRa::begin(unsigned char Tx_Power)
   //Set RFM in LoRa mode
   RFM_Write(0x01,MODE_LORA);
 
-  //PA pin (maximal power)
-  RFM_Write(0x09,Tx_Power);
-
   //Rx Timeout set to 37 symbols
   RFM_Write(0x1F,0x25);
 
@@ -366,6 +361,18 @@ bool TinyLoRa::begin(unsigned char Tx_Power)
   txrandomNum = 0x00;
   return 1;
 }
+
+/**************************************************************************/
+/*! 
+    @brief Sets the TX power
+    @param Tx_Power How much TX power.
+*/
+/**************************************************************************/
+void TinyLoRa::setPower(unsigned char Tx_Power) {
+  //PA pin (default value is 0xff).
+  RFM_Write(0x09,Tx_Power);
+}
+
 
 /**************************************************************************/
 /*!
@@ -502,6 +509,8 @@ uint8_t TinyLoRa::RFM_Read(uint8_t RFM_Address) {
               Frame counter for transfer frames.
     @param    Data_Length
               Length of data to be sent.
+    @param    Frame_Port
+              Number of frame port
 */
 /**************************************************************************/
 void TinyLoRa::sendData(unsigned char *Data, unsigned char Data_Length, unsigned int Frame_Counter_Tx, unsigned char Frame_Port)
@@ -522,7 +531,7 @@ void TinyLoRa::sendData(unsigned char *Data, unsigned char Data_Length, unsigned
   unsigned char Mac_Header = 0x40;
 
   unsigned char Frame_Control = 0x00;
-//  unsigned char Frame_Port = 0x01;
+// TODO Do we need this?  unsigned char Frame_Port;
 
   //make a copy of Data
   unsigned char tmpData[Data_Length];

--- a/TinyLoRa.h
+++ b/TinyLoRa.h
@@ -69,8 +69,8 @@ typedef enum rfm_datarates
 } rfm_datarates_t;
 
 /** Region configuration*/
-//#define US902 ///< Used in USA, Canada and South America
-#define EU863 ///< Used in Europe
+#define US902 ///< Used in USA, Canada and South America
+//#define EU863 ///< Used in Europe
 //#define AU915 ///< Used in Australia
 //#define AS920 ///< Used in Asia
 

--- a/TinyLoRa.h
+++ b/TinyLoRa.h
@@ -69,8 +69,8 @@ typedef enum rfm_datarates
 } rfm_datarates_t;
 
 /** Region configuration*/
-#define US902 ///< Used in USA, Canada and South America
-//#define EU863 ///< Used in Europe
+//#define US902 ///< Used in USA, Canada and South America
+#define EU863 ///< Used in Europe
 //#define AU915 ///< Used in Australia
 //#define AS920 ///< Used in Asia
 
@@ -106,8 +106,9 @@ class TinyLoRa
 		uint16_t frameCounter;  ///<frame counter
     void setChannel(rfm_channels_t channel);
     void setDatarate(rfm_datarates_t datarate);
+    void setPower(unsigned char Tx_Power);
     TinyLoRa(int8_t rfm_dio0, int8_t rfm_nss, int8_t rfm_rst);
-		bool begin(unsigned char Tx_Power);
+		bool begin();
 		void sendData(unsigned char *Data, unsigned char Data_Length, unsigned int Frame_Counter_Tx, unsigned char Frame_Port);
 
 	private:

--- a/TinyLoRa.h
+++ b/TinyLoRa.h
@@ -107,8 +107,8 @@ class TinyLoRa
     void setChannel(rfm_channels_t channel);
     void setDatarate(rfm_datarates_t datarate);
     TinyLoRa(int8_t rfm_dio0, int8_t rfm_nss, int8_t rfm_rst);
-		bool begin(void);
-		void sendData(unsigned char *Data, unsigned char Data_Length, unsigned int Frame_Counter_Tx);
+		bool begin(unsigned char Tx_Power);
+		void sendData(unsigned char *Data, unsigned char Data_Length, unsigned int Frame_Counter_Tx, unsigned char Frame_Port);
 
 	private:
 		uint8_t randomNum;

--- a/examples/hello_LoRa/hello_LoRa.ino
+++ b/examples/hello_LoRa/hello_LoRa.ino
@@ -25,9 +25,32 @@ uint8_t AppSkey[16] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x
 uint8_t DevAddr[4] = { 0x00, 0x00, 0x00, 0x00 };
 
 /************************** Example Begins Here ***********************************/
-// setup TX settings
-uint8_t const TxPower = 0xff; // Default 0xff.
-uint8_t FramePort = 2;
+// Start TxPower settings //
+uint8_t const TxPower = 0xFF; // default value. Don't modify this value [default: 0xFF]
+
+// uncomment this section if you want to control the TxPower, and comment the above line.
+/*
+bool PaBoost = 1; // 8th bit [default: 1]
+uint8_t OutputPower = 1; // 1-4 bit (DEC values: 0-15) [default: 15] +2 to +17dBm.
+uint8_t MaxPower = 4; // 5-7 bit, (DEC values: 0-7) [default: 4] BUG? Range -4 to 0 but DOC says -4 to +15dBm
+
+// function to pack the data for TXpower.
+uint8_t packDataPower(){
+  // According to HOPE RFM9x documentation (p. 80 section 5.4.3), if PA_LF or PA_HF is used instead of PaBoost, output power must be disabled!
+  if ( PaBoost == 0 && OutputPower > 0 ) {
+     OutputPower = 0; // make sure OutputPower is disabled if PA_LF or PA_HF is used.
+    }
+
+  uint8_t DataPower = (PaBoost << 7) + (MaxPower << 4) + OutputPower;
+  return DataPower;
+}
+
+// necessary for the initial setup.
+uint8_t TxPower = packDataPower();
+*/
+
+// Port number.
+uint8_t FramePort = 1;
 
 // Data Packet to Send to TTN
 unsigned char loraData[11] = {"hello LoRa"};
@@ -56,12 +79,17 @@ void setup()
   lora.setChannel(MULTI);
   // set datarate
   lora.setDatarate(SF7BW125);
-  if(!lora.begin(TxPower))
+  
+  if(!lora.begin())
   {
     Serial.println("Failed");
     Serial.println("Check your radio");
     while(true);
   }
+  
+  // ATTN: setPower *after* lora.begin or feather 32u4 hangs, untested with M0.
+  lora.setPower(TxPower);
+  
   Serial.println("OK");
 }
 

--- a/examples/hello_LoRa/hello_LoRa.ino
+++ b/examples/hello_LoRa/hello_LoRa.ino
@@ -25,6 +25,10 @@ uint8_t AppSkey[16] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x
 uint8_t DevAddr[4] = { 0x00, 0x00, 0x00, 0x00 };
 
 /************************** Example Begins Here ***********************************/
+// setup TX settings
+uint8_t const TxPower = 0xff; // Default 0xff.
+uint8_t FramePort = 2;
+
 // Data Packet to Send to TTN
 unsigned char loraData[11] = {"hello LoRa"};
 
@@ -52,7 +56,7 @@ void setup()
   lora.setChannel(MULTI);
   // set datarate
   lora.setDatarate(SF7BW125);
-  if(!lora.begin())
+  if(!lora.begin(TxPower))
   {
     Serial.println("Failed");
     Serial.println("Check your radio");
@@ -64,7 +68,7 @@ void setup()
 void loop()
 {
   Serial.println("Sending LoRa Data...");
-  lora.sendData(loraData, sizeof(loraData), lora.frameCounter);
+  lora.sendData(loraData, sizeof(loraData), lora.frameCounter, FramePort);
   Serial.print("Frame Counter: ");Serial.println(lora.frameCounter);
   lora.frameCounter++;
 


### PR DESCRIPTION
Hello there,

Added support for frame port and txpower. I tested only frame port and it works.

I modified **only one** arduino (.ino) example accordingly.

If you like my changes, I will try to correct also the other examples. It's my first time in C and OO, so please review my changes if you agree to include them.

Binary size is exactly the same for 32u4.

(I also added a missing spacebar character)