### PR TITLE
avr guard for pgmspace

### DIFF
--- a/TinyLoRa.h
+++ b/TinyLoRa.h
@@ -37,9 +37,12 @@
 #define TINY_LORA_H
 
 #include <Arduino.h>
-#ifdef (__AVR__)
+#ifdef ARDUINO_ARCH_AVR
   #include <avr/pgmspace.h>
-#endif // defined (__AVR__)
+#endif
+#ifdef ARDUINO_ARCH_ESP32
+  #include <pgmspace.h>
+#endif
 
 // uncomment for debug output
 // #define DEBUG

--- a/TinyLoRa.h
+++ b/TinyLoRa.h
@@ -37,10 +37,9 @@
 #define TINY_LORA_H
 
 #include <Arduino.h>
-#ifdef ARDUINO_ARCH_AVR
+#if defined(ARDUINO_ARCH_AVR)
   #include <avr/pgmspace.h>
-#endif
-#ifdef ARDUINO_ARCH_ESP32
+#elif defined(ARDUINO_ARCH_ESP32)
   #include <pgmspace.h>
 #endif
 

--- a/TinyLoRa.h
+++ b/TinyLoRa.h
@@ -37,7 +37,9 @@
 #define TINY_LORA_H
 
 #include <Arduino.h>
-#include <avr/pgmspace.h>
+#ifdef (__AVR__)
+  #include <avr/pgmspace.h>
+#endif // defined (__AVR__)
 
 // uncomment for debug output
 // #define DEBUG

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TinyLoRa
-version=1.2.0
+version=1.2.1
 author=Adafruit
 maintainer=Adafruit<info@adafruit.com>
 sentence=Tiny LoRa Library for TTN


### PR DESCRIPTION
I am using the libary in a Platformio project running with an ESP32. Building fails as avr/pgmspace.h can not be found, it is located one folder up.