### PR TITLE
set default backward compatible region

### DIFF
--- a/TinyLoRa.h
+++ b/TinyLoRa.h
@@ -73,7 +73,9 @@ typedef enum rfm_datarates
 } rfm_datarates_t;
 
 /** Region configuration*/
-#define US902 ///< Used in USA, Canada and South America
+#if !defined(EU863) && !defined(AU915) && !defined(AS920)  
+  #define US902 ///< Used in USA, Canada and South America
+#endif
 //#define EU863 ///< Used in Europe
 //#define AU915 ///< Used in Australia
 //#define AS920 ///< Used in Asia

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TinyLoRa
-version=1.2.1
+version=1.2.2
 author=Adafruit
 maintainer=Adafruit<info@adafruit.com>
 sentence=Tiny LoRa Library for TTN


### PR DESCRIPTION
I am outside the US. Every time I start a project using this library I have to edit the lib again. It happend often to me, after an update of the library, the project doesnt work anymore because it was reset to default. This little fix allows to define the region in the project instead of in the library, if nothing is defined the US is still default.