### PR TITLE
SetPower function

### DIFF
--- a/TinyLoRa.cpp
+++ b/TinyLoRa.cpp
@@ -91,7 +91,7 @@ const unsigned char PROGMEM TinyLoRa::LoRa_Frequency[8][3] = {
 const unsigned char PROGMEM TinyLoRa::LoRa_Frequency[8][3] = {
 	{ 0xE1, 0xF9, 0xC0 },		//Channel 0 903.900 MHz / 61.035 Hz = 14809536 = 0xE1F9C0
 	{ 0xE2, 0x06, 0x8C },		//Channel 1 904.100 MHz / 61.035 Hz = 14812812 = 0xE2068C
-	{ 0xE2, 0x13, 0x59},		//Channel 2 904.300 MHz / 61.035 Hz = 14816089 = 0xE21359
+	{ 0xE2, 0x13, 0x59 },		//Channel 2 904.300 MHz / 61.035 Hz = 14816089 = 0xE21359
 	{ 0xE2, 0x20, 0x26 },		//Channel 3 904.500 MHz / 61.035 Hz = 14819366 = 0xE22026
 	{ 0xE2, 0x2C, 0xF3 },		//Channel 4 904.700 MHz / 61.035 Hz = 14822643 = 0xE22CF3
 	{ 0xE2, 0x39, 0xC0 },		//Channel 5 904.900 MHz / 61.035 Hz = 14825920 = 0xE239C0
@@ -292,7 +292,7 @@ TinyLoRa::TinyLoRa(int8_t rfm_irq, int8_t rfm_nss, int8_t rfm_rst) {
      @return True if the RFM has been initialized
  */
  /**************************************************************************/
-bool TinyLoRa::begin() 
+bool TinyLoRa::begin()
 {
 
   // start and configure SPI
@@ -330,7 +330,7 @@ bool TinyLoRa::begin()
   //Set RFM in LoRa mode
   RFM_Write(0x01,MODE_LORA);
 
-  //PA pin (maximal power)
+  //PA pin (maximal power, 17dBm)
   RFM_Write(0x09,0xFF);
 
   //Rx Timeout set to 37 symbols
@@ -364,6 +364,83 @@ bool TinyLoRa::begin()
   txrandomNum = 0x00;
   return 1;
 }
+
+/**************************************************************************/
+/*! 
+    @brief Sets the TX power
+    @param Tx_Power How much TX power in dBm
+*/
+/**************************************************************************/
+// user can give dBm from -4 to +20, default 17
+// 18-19dBm are undefined in doc but maybe possible. Here are ignored.
+// Chip works with three modes. This function offer less granularity.
+//
+// Example: user selects -1dBm this function selects -.6dBm via
+// pa: 0, opower: 0, mpower: 6.
+
+/* First option is pa_boost = 0 OutputPower = 0. We select MaxPower 5
+pa: 0 opower: 0 mpower: 0 dBm: -4.20
+pa: 0 opower: 0 mpower: 1 dBm: -3.60
+pa: 0 opower: 0 mpower: 2 dBm: -3.00
+pa: 0 opower: 0 mpower: 3 dBm: -2.40
+pa: 0 opower: 0 mpower: 4 dBm: -1.80
+pa: 0 opower: 0 mpower: 5 dBm: -1.20
+pa: 0 opower: 0 mpower: 6 dBm: -0.60
+pa: 0 opower: 0 mpower: 7 dBm: 0.00
+
+But in reality the dBm's in this set are -100dB with pa_boost = 0
+*/
+
+void TinyLoRa::setPower(int8_t Tx_Power) { 
+
+  // values to packed in one byte
+  bool PaBoost;
+  int8_t OutputPower; // 0-15
+  int8_t MaxPower; // 0-7
+
+  // this value goes to the register
+  uint8_t DataPower;
+
+  // 1st range -4.2 to 0dBm 
+  // formula to find the MaxPower.
+  if ( Tx_Power < -4 ) { // force -4.2dBm, no need to calculate
+    PaBoost = 0;
+    MaxPower = 0;
+    OutputPower = 0;
+  } else if ( Tx_Power >= -4 && Tx_Power < 0 ) {
+    PaBoost = 0;
+    MaxPower = (Tx_Power / -0.6 - 7.8) * -1; // * -1 invert negative number to positive
+  // 2nd range 1 to 17dBm 
+  // formula to find the OutputPower.
+  } else if ( Tx_Power >= 0 && Tx_Power < 2 ) { // assume 1 db is given.
+    PaBoost = 1;
+    MaxPower = 7;
+    OutputPower = 1;
+  } else if ( Tx_Power >= 2 && Tx_Power <=17 ) {
+    PaBoost = 1;
+    MaxPower = 7;
+    OutputPower = Tx_Power - 2;
+  }
+
+  // 3rd possibility. 20dBm. Special case
+  // Max Antenna VSWR 3:1, Duty Cycle <1% or destroyed chip
+  if ( Tx_Power == 20 ) {
+    PaBoost = 1;
+    OutputPower = 15;
+    MaxPower = 7;
+    RFM_Write(REG_PA_DAC, 0x87); // only for +20dBm probably with 0x86,0x85 = 19,18dBm
+  } else {
+    // Setting for non +20dBm power
+    RFM_Write(REG_PA_DAC, 0x84);
+  }
+
+  // Pack the above data to one byte and send it to HOPE RFM9x
+  DataPower = (PaBoost << 7) + (MaxPower << 4) + OutputPower;
+  	
+  //PA pin (default value is 0x4F (DEC 79, 3dBm) from HOPE, 0xFF (DEC 255 / 17dBm) from adafruit).
+   RFM_Write(REG_PA_CONFIG,DataPower);
+}
+
 
 /**************************************************************************/
 /*!
@@ -501,7 +578,7 @@ uint8_t TinyLoRa::RFM_Read(uint8_t RFM_Address) {
     @param    Data_Length
               Length of data to be sent.
     @param    Frame_Port
-              Frame port to send data from, from 0 to 225.
+              Number of frame port
 */
 /**************************************************************************/
 void TinyLoRa::sendData(unsigned char *Data, unsigned char Data_Length, unsigned int Frame_Counter_Tx, uint8_t Frame_Port)

--- a/TinyLoRa.h
+++ b/TinyLoRa.h
@@ -69,8 +69,8 @@ typedef enum rfm_datarates
 } rfm_datarates_t;
 
 /** Region configuration*/
-#define US902 ///< Used in USA, Canada and South America
-//#define EU863 ///< Used in Europe
+//#define US902 ///< Used in USA, Canada and South America
+#define EU863 ///< Used in Europe
 //#define AU915 ///< Used in Australia
 //#define AS920 ///< Used in Asia
 
@@ -84,6 +84,7 @@ typedef enum rfm_datarates
 
 /* RFM Registers */
 #define REG_PA_CONFIG              0x09 ///<PA selection and Output Power control
+#define REG_PA_DAC	           0x4D ///<PA Higher Power Settings
 #define REG_PREAMBLE_MSB           0x20 ///<Preamble Length, MSB
 #define REG_PREAMBLE_LSB           0x21 ///<Preamble Length, LSB
 #define REG_FRF_MSB                0x06 ///<RF Carrier Frequency MSB
@@ -106,6 +107,7 @@ class TinyLoRa
 		uint16_t frameCounter;  ///<frame counter
     void setChannel(rfm_channels_t channel);
     void setDatarate(rfm_datarates_t datarate);
+    void setPower(int8_t Tx_Power = 17);
     TinyLoRa(int8_t rfm_dio0, int8_t rfm_nss, int8_t rfm_rst);
 		bool begin(void);
 		void sendData(unsigned char *Data, unsigned char Data_Length, unsigned int Frame_Counter_Tx, uint8_t Frame_Port = 1);

--- a/TinyLoRa.h
+++ b/TinyLoRa.h
@@ -37,7 +37,11 @@
 #define TINY_LORA_H
 
 #include <Arduino.h>
-#include <avr/pgmspace.h>
+#if defined(ARDUINO_ARCH_AVR)
+  #include <avr/pgmspace.h>
+#elif defined(ARDUINO_ARCH_ESP32)
+  #include <pgmspace.h>
+#endif
 
 // uncomment for debug output
 // #define DEBUG
@@ -105,23 +109,23 @@ class TinyLoRa
 	public:
 		uint8_t txrandomNum;  ///<random number for AES
 		uint16_t frameCounter;  ///<frame counter
-    void setChannel(rfm_channels_t channel);
-    void setDatarate(rfm_datarates_t datarate);
-    void setPower(int8_t Tx_Power = 17);
-    TinyLoRa(int8_t rfm_dio0, int8_t rfm_nss, int8_t rfm_rst);
+		void setChannel(rfm_channels_t channel);
+		void setDatarate(rfm_datarates_t datarate);
+		void setPower(int8_t Tx_Power = 17);
+		TinyLoRa(int8_t rfm_dio0, int8_t rfm_nss, int8_t rfm_rst);
 		bool begin(void);
 		void sendData(unsigned char *Data, unsigned char Data_Length, unsigned int Frame_Counter_Tx, uint8_t Frame_Port = 1);
 
 	private:
 		uint8_t randomNum;
 		int8_t _cs, _irq, _rst;
-    bool _isMultiChan;
-    unsigned char _rfmMSB, _rfmMID, _rfmLSB, _sf, _bw, _modemcfg;
-    static const unsigned char LoRa_Frequency[8][3];
+		bool _isMultiChan;
+		unsigned char _rfmMSB, _rfmMID, _rfmLSB, _sf, _bw, _modemcfg;
+		static const unsigned char LoRa_Frequency[8][3];
 		static const unsigned char S_Table[16][16];
 		void RFM_Send_Package(unsigned char *RFM_Tx_Package, unsigned char Package_Length);
 		void RFM_Write(unsigned char RFM_Address, unsigned char RFM_Data);
-    uint8_t RFM_Read(uint8_t RFM_Address);
+		uint8_t RFM_Read(uint8_t RFM_Address);
 		void Encrypt_Payload(unsigned char *Data, unsigned char Data_Length, unsigned int Frame_Counter, unsigned char Direction);
 		void Calculate_MIC(unsigned char *Data, unsigned char *Final_MIC, unsigned char Data_Length, unsigned int Frame_Counter, unsigned char Direction);
 		void Generate_Keys(unsigned char *K1, unsigned char *K2);

--- a/TinyLoRa.h
+++ b/TinyLoRa.h
@@ -73,8 +73,8 @@ typedef enum rfm_datarates
 } rfm_datarates_t;
 
 /** Region configuration*/
-//#define US902 ///< Used in USA, Canada and South America
-#define EU863 ///< Used in Europe
+#define US902 ///< Used in USA, Canada and South America
+//#define EU863 ///< Used in Europe
 //#define AU915 ///< Used in Australia
 //#define AS920 ///< Used in Asia
 

--- a/TinyLoRa.h
+++ b/TinyLoRa.h
@@ -73,7 +73,9 @@ typedef enum rfm_datarates
 } rfm_datarates_t;
 
 /** Region configuration*/
-#define US902 ///< Used in USA, Canada and South America
+#if !defined(EU863) && !defined(AU915) && !defined(AS920)  
+  #define US902 ///< Used in USA, Canada and South America
+#endif
 //#define EU863 ///< Used in Europe
 //#define AU915 ///< Used in Australia
 //#define AS920 ///< Used in Asia

--- a/examples/hello_LoRa/hello_LoRa.ino
+++ b/examples/hello_LoRa/hello_LoRa.ino
@@ -25,6 +25,10 @@ uint8_t AppSkey[16] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x
 uint8_t DevAddr[4] = { 0x00, 0x00, 0x00, 0x00 };
 
 /************************** Example Begins Here ***********************************/
+// setup TX settings
+uint8_t const TxPower = 0xff; // Default 0xff.
+uint8_t FramePort = 2;
+
 // Data Packet to Send to TTN
 unsigned char loraData[11] = {"hello LoRa"};
 
@@ -58,16 +62,20 @@ void setup()
     Serial.println("Check your radio");
     while(true);
   }
+
+  // Optional set transmit power. If not set default is +17 dBm.
+  // Valid options are: -80, 1 to 17, 20dBm.
+  // For safe operation in 20dBm: your antenna must be 3:1 VWSR or better
+  // and respect the 1% duty cycle.
+  // lora.setPower(17);
+
   Serial.println("OK");
 }
 
 void loop()
 {
   Serial.println("Sending LoRa Data...");
-  lora.sendData(loraData, sizeof(loraData), lora.frameCounter);
-  // Optionally set the Frame Port (1 to 255)
-  // uint8_t framePort = 1;
-  // lora.sendData(loraData, sizeof(loraData), lora.frameCounter, framePort);
+  lora.sendData(loraData, sizeof(loraData), lora.frameCounter, FramePort);
   Serial.print("Frame Counter: ");Serial.println(lora.frameCounter);
   lora.frameCounter++;
 

--- a/examples/hello_LoRa/hello_LoRa.ino
+++ b/examples/hello_LoRa/hello_LoRa.ino
@@ -25,10 +25,6 @@ uint8_t AppSkey[16] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x
 uint8_t DevAddr[4] = { 0x00, 0x00, 0x00, 0x00 };
 
 /************************** Example Begins Here ***********************************/
-// setup TX settings
-uint8_t const TxPower = 0xff; // Default 0xff.
-uint8_t FramePort = 2;
-
 // Data Packet to Send to TTN
 unsigned char loraData[11] = {"hello LoRa"};
 
@@ -64,9 +60,10 @@ void setup()
   }
 
   // Optional set transmit power. If not set default is +17 dBm.
-  // Valid options are: -80, 1 to 17, 20dBm.
+  // Valid options are: -80, 1 to 17, 20 (dBm).
   // For safe operation in 20dBm: your antenna must be 3:1 VWSR or better
   // and respect the 1% duty cycle.
+
   // lora.setPower(17);
 
   Serial.println("OK");
@@ -75,7 +72,10 @@ void setup()
 void loop()
 {
   Serial.println("Sending LoRa Data...");
-  lora.sendData(loraData, sizeof(loraData), lora.frameCounter, FramePort);
+  lora.sendData(loraData, sizeof(loraData), lora.frameCounter);
+  // Optionally set the Frame Port (1 to 255)
+  // uint8_t framePort = 1;
+  // lora.sendData(loraData, sizeof(loraData), lora.frameCounter, framePort);
   Serial.print("Frame Counter: ");Serial.println(lora.frameCounter);
   lora.frameCounter++;
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TinyLoRa
-version=1.2.0
+version=1.3
 author=Adafruit
 maintainer=Adafruit<info@adafruit.com>
 sentence=Tiny LoRa Library for TTN

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TinyLoRa
-version=1.2.1
+version=1.2.2
 author=Adafruit
 maintainer=Adafruit<info@adafruit.com>
 sentence=Tiny LoRa Library for TTN


### PR DESCRIPTION
Third attempt for `setPower` support, it's user-friendly. 'User' optionally writes `lora.setPower(17);` to set +17dBm, or `lora.setPower(-80)` for -80dBm. If user does not use lora.setPower(), default is +17dBm (like adafruit original TinyLoRa). But I discovered some weird stuff.

1. The documentation I think is wrong, or I didn't understood something! I would like someone to verify my remarks. p. 79 and p. 89 documentation states:
i. `Pmax = 10.8 * 0.6 * MaxPower` [dBm] (this seems ok)
ii. `Pout = Pmax - (15 - OutputPower)` [dBm] instead of 
iii. `Pout = Pmax - (15 + OutputPower)` [dBm] It's not logical with increased power to have less dBm's!
Datasheet / Documentation: https://www.hoperf.com/data/upload/portal/20190801/RFM95W-V2.0.pdf

So I use the last (iii) formula for the calculations, not the documentation's (ii).

2. Even more bizzare. The documentation says the range is -4 to +17dBm (+20 special case), but in my test is -80 to +17 (+20 untested). Huge gap between 0 and -80dBm. I didn't test +20.

3. We have three options with HOPE RFM9x.
a. without PA_BOOST (-4 to +15dBm) - in my tests: approx. -75 to -84.
b. with PA_BOOST (0 to +17dBm) - in my tests: -0,20 to -14,50 (see first test)
c. with PA_BOOST and HI_POWER (aka: +20dBm) - untested. It requires antenna with at least 3:1 VWSR (I have DIY antenna with cable 1/4 monopole as stated in adafruit tutorial). I don't want to risk damage.

Conclusions

1. It works.
2. Greeater range than documented. Instead of -4 to +20, -84 to +20.

and finally
3. Does not break old .ino's like my first attempt.
4. I can submit an ino file that cycles `lora.setPower`.

Happy testing / undestanding.

To undestand the situation I also wrote a c program https://github.com/clavisound/hope-rfm9x/blob/master/hope-rfm9x-dbm.c I wanted to check which values are easy / meaningful to use. I think it's overkill:

a. to have access to all combinations (some are overlapping).
b. Granularity of 1dBm is fine.

How setPower works:
The chip has 4 (four) possible 'values' in two registers. PA_BOOST, MAX_POWER, OUTPUT_POWER (one register), HIGH_POWER_SETTINGS (second register). With the c programm, I tried to deciph what I needed.

So I splitted the options in three categories / ranges.

1. -4 to 0dBm is abandoned (in reality -80 to -83). Overkill to have this option. I kept only -80 option. PA_BOOST forbidden, HIGH_POWER_SETTINGS disabled (aka value 0x84), OUTPUT_POWER=0, MAX_POWER variable 0 to 7
2. 0 to 17dBm PA_BOOST enabled, HIGH_POWER_SETTINGS disabled, OUTPUT_POWER=0 to 15, MAX_POWER=7
3. 20 (untested) PA_BOOST ENABLED, HIGH_POWER_SETTINGS enabled (aka value 0x87), OUTPUT_POWER=15, MAX_POWER=7

Tests not done:

1. compare the power consumption -80dBm vs +17dBm

Testing made with SF7, approx. 12cm distance from concentrator (n-fuse, 2dBi antenna) @CH7 (867.9Mhz). DIY antenna on adafruit LoRa, not optimized.

setPower uses this range with values: PaBoost = 1, MaxPower = 7, OutputPower = 0-15.
```
dBm (setPower)	RSSI (n-fuse)	SNR		sum
17		-10		9,80		-0,20
16		-7		9		2
15		-10		9,50		-0,50
14		-11		9,80		-1,20
13		-13		9,80		-3,20
12		-13		11		-2
11		-15		9,80		-5,20
10		-16		9		-7
8		-19		9		-10
7		-19		10		-9
6		-20		8,50		-11,50
5		-22		10,50		-11,50
4		-25		9,80		-15,20
4		-23		9,80		-13,20
3		-27		9,50		-17,50
2		-27		10,50		-16,50
1		-25		10,50		-14,50

```
Tests done with 'private' library.

This is wrong. Instead of -4dBm it seems approx. -80dBm. No reception in 3 meters and SF10, I don't find usefull to deploy this range: overkill to my taste. Using only -80 (equals -84).
(MaxPower = 0-7, OutputPower 0)
```
-79		-100		8,50		-91,50
-80		-104		7		-97
-81		-103		5		-98
-82		-104		3,20		-100,80
-83		-103		5,20		-97,80
-84		-102		5,20		-96,80
```

Only 4dB more power that previous test. Also not deployed to this library.

Experiment with MaxPower = 7, OutputPower 0-15)
```
OutputPower	RSSI		SNR		sum
1		-96		7,80		-88,20
2		-99		9		-90
3		-98		7,20		-90,80
4		-99		6,80		-92,20
5		-98		7,20		-90,80
6		-99		7,80		-91,20
7		-99		7,20		-91,80
8		-101		7,50		-93,50
9		-99		7,80		-91,20
10		-101		7,80		-93,20
11		-98		8		-90
12		-97		8,50		-88,50
13		-96		8		-88
14		-98		7,50		-90,50
```

I have also added / deleted some whitespaces.